### PR TITLE
refactor: simplify users table definition by removing redundant colum…

### DIFF
--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,62 +9,62 @@ import {
 import { relations } from 'drizzle-orm';
 
 export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  name: varchar('name', { length: 100 }),
-  email: varchar('email', { length: 255 }).notNull().unique(),
-  passwordHash: text('password_hash').notNull(),
-  role: varchar('role', { length: 20 }).notNull().default('member'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-  deletedAt: timestamp('deleted_at'),
+  id: serial().primaryKey(),
+  name: varchar({ length: 100 }),
+  email: varchar({ length: 255 }).notNull().unique(),
+  passwordHash: text().notNull(),
+  role: varchar({ length: 20 }).notNull().default('member'),
+  createdAt: timestamp().notNull().defaultNow(),
+  updatedAt: timestamp().notNull().defaultNow(),
+  deletedAt: timestamp(),
 });
 
 export const teams = pgTable('teams', {
-  id: serial('id').primaryKey(),
-  name: varchar('name', { length: 100 }).notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-  stripeCustomerId: text('stripe_customer_id').unique(),
-  stripeSubscriptionId: text('stripe_subscription_id').unique(),
-  stripeProductId: text('stripe_product_id'),
-  planName: varchar('plan_name', { length: 50 }),
-  subscriptionStatus: varchar('subscription_status', { length: 20 }),
+  id: serial().primaryKey(),
+  name: varchar({ length: 100 }).notNull(),
+  createdAt: timestamp().notNull().defaultNow(),
+  updatedAt: timestamp().notNull().defaultNow(),
+  stripeCustomerId: text().unique(),
+  stripeSubscriptionId: text().unique(),
+  stripeProductId: text(),
+  planName: varchar({ length: 50 }),
+  subscriptionStatus: varchar({ length: 20 }),
 });
 
 export const teamMembers = pgTable('team_members', {
   id: serial('id').primaryKey(),
-  userId: integer('user_id')
+  userId: integer()
     .notNull()
     .references(() => users.id),
-  teamId: integer('team_id')
+  teamId: integer()
     .notNull()
     .references(() => teams.id),
   role: varchar('role', { length: 50 }).notNull(),
-  joinedAt: timestamp('joined_at').notNull().defaultNow(),
+  joinedAt: timestamp().notNull().defaultNow(),
 });
 
 export const activityLogs = pgTable('activity_logs', {
-  id: serial('id').primaryKey(),
-  teamId: integer('team_id')
+  id: serial().primaryKey(),
+  teamId: integer()
     .notNull()
     .references(() => teams.id),
-  userId: integer('user_id').references(() => users.id),
-  action: text('action').notNull(),
-  timestamp: timestamp('timestamp').notNull().defaultNow(),
-  ipAddress: varchar('ip_address', { length: 45 }),
+  userId: integer().references(() => users.id),
+  action: text().notNull(),
+  timestamp: timestamp().notNull().defaultNow(),
+  ipAddress: varchar({ length: 45 }),
 });
 
 export const invitations = pgTable('invitations', {
-  id: serial('id').primaryKey(),
-  teamId: integer('team_id')
+  id: serial().primaryKey(),
+  teamId: integer(')
     .notNull()
     .references(() => teams.id),
-  email: varchar('email', { length: 255 }).notNull(),
-  role: varchar('role', { length: 50 }).notNull(),
-  invitedBy: integer('invited_by')
+  email: varchar({ length: 255 }).notNull(),
+  role: varchar({ length: 50 }).notNull(),
+  invitedBy: integer()
     .notNull()
     .references(() => users.id),
-  invitedAt: timestamp('invited_at').notNull().defaultNow(),
+  invitedAt: timestamp().notNull().defaultNow(),
   status: varchar('status', { length: 20 }).notNull().default('pending'),
 });
 


### PR DESCRIPTION
…n names

Drizzle automatically converts camelCase to snake_case when creating a database from the schema.

So when you have:
```js
deletedAt: timestamp()
```

Its the same as:
```js
deletedAt: timestamp("deleted_at")
```

Just a small refactor.