### PR TITLE
Extends session expiration on GET request only

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,7 +15,7 @@ export async function middleware(request: NextRequest) {
 
   let res = NextResponse.next();
 
-  if (sessionCookie) {
+  if (sessionCookie && request.method === "GET") {
     try {
       const parsed = await verifyToken(sessionCookie.value);
       const expiresInOneDay = new Date(Date.now() + 24 * 60 * 60 * 1000);


### PR DESCRIPTION
In most of the time, logout will result in the following headers:
```
"set-cookie": "session=xxxxxxxxxxxx; Path=/; Expires=Sat, 08 Mar 2025 13:06:12 GMT; Secure; HttpOnly; SameSite=lax"
"set-cookie": "session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
```
However, sometimes it will result in the following instead, due to the session expiration being extended in middleware:
```
"set-cookie": "session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
"set-cookie": "session=xxxxxxxxxxxx; Path=/; Expires=Sat, 08 Mar 2025 13:06:12 GMT; Secure; HttpOnly; SameSite=lax"
```
Which causes a bug where users can never log out properly.

The solution is to only extend the session expiration when the request method is `GET`, to prevent it from overriding the session cookie set by the server action.