### PR TITLE
Revalidate path on account information update

### DIFF
--- a/app/(login)/actions.ts
+++ b/app/(login)/actions.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/db/schema';
 import { comparePasswords, hashPassword, setSession } from '@/lib/auth/session';
 import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { createCheckoutSession } from '@/lib/payments/stripe';
 import { getUser, getUserWithTeam } from '@/lib/db/queries';
@@ -336,6 +337,8 @@ export const updateAccount = validatedActionWithUser(
       db.update(users).set({ name, email }).where(eq(users.id, user.id)),
       logActivity(userWithTeam?.teamId, user.id, ActivityType.UPDATE_ACCOUNT),
     ]);
+
+    revalidatePath('/dashboard/general');
 
     return { success: 'Account updated successfully.' };
   },


### PR DESCRIPTION
General Settings page in the dashboard still displays the old data after the account information has been updated. Therefore, I added `revalidatePath` into the `updateAccount` action.

Issue Screencast:

https://github.com/user-attachments/assets/73c39b6f-be89-4958-b222-3ba51947a898