### PR TITLE
Updated duplicate user error message to be clearer 

### DIFF
--- a/app/(login)/actions.ts
+++ b/app/(login)/actions.ts
@@ -117,7 +117,7 @@ export const signUp = validatedAction(signUpSchema, async (data, formData) => {
 
   if (existingUser.length > 0) {
     return {
-      error: 'Failed to create user. Please try again.',
+      error: 'This user already exists. Please try a different email.',
       email,
       password
     };


### PR DESCRIPTION
When a user tries to create an account with a duplicated email, the error message is unclear & the suggested action does not resolve the error.

I've updated the error message for the user duplication to be more clear and the recommended action to be more useful.