### PR TITLE
Replace deprecated tailwindcss animation library

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ In your Vercel project settings (or during deployment), add all the necessary en
 
 While this template is intentionally minimal and to be used as a learning resource, there are other paid versions in the community which are more full-featured:
 
+- https://turbostarter.dev
 - https://achromatic.dev
 - https://shipfa.st
 - https://makerkit.dev

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ In your Vercel project settings (or during deployment), add all the necessary en
 
 While this template is intentionally minimal and to be used as a learning resource, there are other paid versions in the community which are more full-featured:
 
-- https://turbostarter.dev
 - https://achromatic.dev
 - https://shipfa.st
 - https://makerkit.dev
 - https://zerotoshipped.com
+- https://turbostarter.dev

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,10 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 /*
   ---break---
 */
 @custom-variant dark (&:is(.dark *));
 
-@plugin 'tailwindcss-animate';
+@import "tw-animate-css";
 
 @variant dark (&:is(.dark *));
 
@@ -77,7 +77,7 @@
 
 @layer utilities {
   body {
-    font-family: 'Manrope', Arial, Helvetica, sans-serif;
+    font-family: "Manrope", Arial, Helvetica, sans-serif;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "swr": "^2.3.3",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "4.1.7",
-    "tailwindcss-animate": "^1.0.7",
+    "tw-animate-css": "^1.3.0",
     "typescript": "^5.8.3",
     "zod": "^3.24.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,9 @@ importers:
       tailwindcss:
         specifier: 4.1.7
         version: 4.1.7
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@4.1.7)
+      tw-animate-css:
+        specifier: ^1.3.0
+        version: 1.3.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1589,11 +1589,6 @@ packages:
   tailwind-merge@3.3.0:
     resolution: {integrity: sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==}
 
-  tailwindcss-animate@1.0.7:
-    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
-
   tailwindcss@4.1.7:
     resolution: {integrity: sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==}
 
@@ -1607,6 +1602,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tw-animate-css@1.3.0:
+    resolution: {integrity: sha512-jrJ0XenzS9KVuDThJDvnhalbl4IYiMQ/XvpA0a2FL8KmlK+6CSMviO7ROY/I7z1NnUs5NnDhlM6fXmF40xPxzw==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -2846,10 +2844,6 @@ snapshots:
 
   tailwind-merge@3.3.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@4.1.7):
-    dependencies:
-      tailwindcss: 4.1.7
-
   tailwindcss@4.1.7: {}
 
   tapable@2.2.1: {}
@@ -2864,6 +2858,8 @@ snapshots:
       yallist: 5.0.0
 
   tslib@2.8.1: {}
+
+  tw-animate-css@1.3.0: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
Replacing `tailwindcss-animate` (that wasn't updated for years) with new `tw-animate-css` library which is a pure CSS solution leveraging CSS-first architecture compatible with Tailwind v4

https://github.com/Wombosvideo/tw-animate-css