### PR TITLE
fix: mutate instead of router.refresh

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -14,7 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { signOut } from '@/app/(login)/actions';
 import { useRouter } from 'next/navigation';
 import { User } from '@/lib/db/schema';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -25,7 +25,7 @@ function UserMenu() {
 
   async function handleSignOut() {
     await signOut();
-    router.refresh();
+    mutate('/api/user');
     router.push('/');
   }
 


### PR DESCRIPTION
## Mutate user data instead of only refreshing

When the user signs out, the data is still in the cache, and the option to sign out is still available, causing an error. Instead of the user having to refresh the webpage, can mutate the user api route.