### PR TITLE
Sync schema and Stripe on build, remove `BASE_URL`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,4 @@
 POSTGRES_URL=postgresql://***
 STRIPE_SECRET_KEY=sk_test_***
 STRIPE_WEBHOOK_SECRET=whsec_***
-BASE_URL=http://localhost:3000
 AUTH_SECRET=***

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ When you're ready to deploy your SaaS application to production, follow these st
 
 In your Vercel project settings (or during deployment), add all the necessary environment variables. Make sure to update the values for the production environment, including:
 
-1. `BASE_URL`: Set this to your production domain.
 2. `STRIPE_SECRET_KEY`: Use your Stripe secret key for the production environment.
 3. `STRIPE_WEBHOOK_SECRET`: Use the webhook secret from the production webhook you created in step 1.
 4. `POSTGRES_URL`: Set this to your production database URL.

--- a/app/(dashboard)/pricing/page.tsx
+++ b/app/(dashboard)/pricing/page.tsx
@@ -1,20 +1,28 @@
 import { checkoutAction } from '@/lib/payments/actions';
 import { Check } from 'lucide-react';
 import { getStripePrices, getStripeProducts } from '@/lib/payments/stripe';
+import { createStripeProducts } from '@/lib/db/seed';
 import { SubmitButton } from './submit-button';
 
 // Prices are fresh for one hour max
 export const revalidate = 3600;
 
 export default async function PricingPage() {
-  const [prices, products] = await Promise.all([
+  let [prices, products] = await Promise.all([
     getStripePrices(),
     getStripeProducts(),
   ]);
 
+  if (products.length === 0 && prices.length === 0) {
+    await createStripeProducts();
+    [prices, products] = await Promise.all([
+      getStripePrices(),
+      getStripeProducts(),
+    ]);
+  }
+
   const basePlan = products.find((product) => product.name === 'Base');
   const plusPlan = products.find((product) => product.name === 'Plus');
-
   const basePrice = prices.find((price) => price.productId === basePlan?.id);
   const plusPrice = prices.find((price) => price.productId === plusPlan?.id);
 

--- a/lib/db/seed-runner.ts
+++ b/lib/db/seed-runner.ts
@@ -1,0 +1,11 @@
+import { seed } from "./seed";
+
+seed()
+  .catch((error) => {
+    console.error('Seed process failed:', error);
+    process.exit(1);
+  })
+  .finally(() => {
+    console.log('Seed process finished. Exiting...');
+    process.exit(0);
+  });

--- a/lib/db/seed.ts
+++ b/lib/db/seed.ts
@@ -39,7 +39,7 @@ export async function createStripeProducts() {
   console.log('Stripe products and prices created successfully.');
 }
 
-async function seed() {
+export async function seed() {
   const email = 'test@test.com';
   const password = 'admin123';
   const passwordHash = await hashPassword(password);
@@ -72,13 +72,3 @@ async function seed() {
 
   await createStripeProducts();
 }
-
-seed()
-  .catch((error) => {
-    console.error('Seed process failed:', error);
-    process.exit(1);
-  })
-  .finally(() => {
-    console.log('Seed process finished. Exiting...');
-    process.exit(0);
-  });

--- a/lib/db/seed.ts
+++ b/lib/db/seed.ts
@@ -3,7 +3,7 @@ import { db } from './drizzle';
 import { users, teams, teamMembers } from './schema';
 import { hashPassword } from '@/lib/auth/session';
 
-async function createStripeProducts() {
+export async function createStripeProducts() {
   console.log('Creating Stripe products and prices...');
 
   const baseProduct = await stripe.products.create({

--- a/lib/db/setup.ts
+++ b/lib/db/setup.ts
@@ -199,14 +199,12 @@ async function main() {
   const POSTGRES_URL = await getPostgresURL();
   const STRIPE_SECRET_KEY = await getStripeSecretKey();
   const STRIPE_WEBHOOK_SECRET = await createStripeWebhook();
-  const BASE_URL = 'http://localhost:3000';
   const AUTH_SECRET = generateAuthSecret();
 
   await writeEnvFile({
     POSTGRES_URL,
     STRIPE_SECRET_KEY,
     STRIPE_WEBHOOK_SECRET,
-    BASE_URL,
     AUTH_SECRET,
   });
 

--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -7,6 +7,11 @@ import {
   updateTeamSubscription
 } from '@/lib/db/queries';
 
+const vercelUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+const baseUrl = vercelUrl
+  ? `https://${vercelUrl}`
+  : 'http://localhost:3000'
+
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2025-04-30.basil'
 });
@@ -33,8 +38,8 @@ export async function createCheckoutSession({
       }
     ],
     mode: 'subscription',
-    success_url: `${process.env.BASE_URL}/api/stripe/checkout?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${process.env.BASE_URL}/pricing`,
+    success_url: `${baseUrl}/api/stripe/checkout?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${baseUrl}/pricing`,
     customer: team.stripeCustomerId || undefined,
     client_reference_id: user.id.toString(),
     allow_promotion_codes: true,
@@ -109,7 +114,7 @@ export async function createCustomerPortalSession(team: Team) {
 
   return stripe.billingPortal.sessions.create({
     customer: team.stripeCustomerId,
-    return_url: `${process.env.BASE_URL}/dashboard`,
+    return_url: `${baseUrl}/dashboard`,
     configuration: configuration.id
   });
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "db:seed": "npx tsx lib/db/seed.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "postinstall": "drizzle-kit push"
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "next build",
     "start": "next start",
     "db:setup": "npx tsx lib/db/setup.ts",
-    "db:seed": "npx tsx lib/db/seed.ts",
+    "db:seed": "npx tsx lib/db/seed-runner.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
This PR:

- Fixes the issue where a deployed version of the template isn't guaranteed to have its database synced with the schema
- Adds automatic creation of Stripe products & prices if they don't already exist
- Removes the need to set `BASE_URL`, favoring [`VERCEL_PROJECT_PRODUCTION_URL`](https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_PROJECT_PRODUCTION_URL)
