### PR TITLE
fix: team member removal button visibility and pending state

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -153,7 +153,7 @@ function TeamMembers() {
                   </p>
                 </div>
               </div>
-              {index > 1 ? (
+              {index >= 1 ? (
                 <form action={removeAction}>
                   <input type="hidden" name="memberId" value={member.id} />
                   <Button

--- a/app/(login)/actions.ts
+++ b/app/(login)/actions.ts
@@ -359,7 +359,7 @@ export const updateAccount = validatedActionWithUser(
 );
 
 const removeTeamMemberSchema = z.object({
-  memberId: z.number()
+  memberId: z.string().transform((val) => Number(val)),
 });
 
 export const removeTeamMember = validatedActionWithUser(

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -122,10 +122,11 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type TeamMemberWithUser = TeamMember & {
+  user: Pick<User, "id" | "name" | "email">;
+};
 export type TeamDataWithMembers = Team & {
-  teamMembers: (TeamMember & {
-    user: Pick<User, 'id' | 'name' | 'email'>;
-  })[];
+  teamMembers: TeamMemberWithUser[];
 };
 
 export enum ActivityType {


### PR DESCRIPTION
Changes

- Updated the condition to index > 0 so all members except the first (typically the owner) show the button.
- Extracted each member row into a TeamMemberRow component to allow hiding the row after removal.
- Each button now handles its own pending state independently.

Before:

https://github.com/user-attachments/assets/fe8f30bf-a23c-4872-be21-0d668f54826c

After:

https://github.com/user-attachments/assets/0c311259-9577-4ba1-b5aa-8adae3c62ab8

