### PR TITLE
feat: Prompt 9 — Compliance Hardening (Immutable Sign-offs, Audit Trail, Tamper-Evident PDF)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Next.js SaaS Starter app (Next.js App Router + Drizzle ORM + PostgreSQL + Stripe). pnpm is the package manager.
+
+### Services & how to run them
+- **PostgreSQL**: required for the app to boot. It is installed via the system package manager (cluster `16/main`) and is **not auto-started on boot** — start it with `sudo pg_ctlcluster 16 main start`. Connection used by `.env`: `postgres://postgres:postgres@localhost:5432/postgres` (standard port 5432, not the 54322 mentioned in the README's Docker flow).
+- **Next.js dev server**: `pnpm dev` (Turbopack) on http://localhost:3000.
+- After a fresh DB or schema change, apply migrations with `pnpm db:migrate`. Tables: `users`, `teams`, `team_members`, `activity_logs`, `invitations`.
+
+### Environment / `.env` (gotchas)
+- `.env` is git-ignored and is **managed manually** here (do NOT run `pnpm db:setup` — it is interactive and requires the Stripe CLI + Docker). Required vars: `POSTGRES_URL`, `AUTH_SECRET`, `BASE_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
+- `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` are **placeholders**. Core flows (sign-up, sign-in, dashboard, team/activity) work fully without real Stripe keys. Stripe-dependent flows do **not** work with placeholders:
+  - `pnpm db:seed` calls `createStripeProducts()` and will fail without a real Stripe key — it is not needed to exercise core auth/dashboard. Create users via the `/sign-up` route instead.
+  - `/pricing` checkout and the customer-portal flow require a real Stripe test key + `stripe listen` webhook forwarding.
+
+### Lint / test / build
+- There are **no `lint` or `test` scripts** defined in `package.json`. Use `npx tsc --noEmit` for type checking.
+- Production build is `pnpm build`; for development use `pnpm dev`.

--- a/app/(dashboard)/dashboard/jobs/[id]/download-traveler-pdf.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/download-traveler-pdf.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Download, Loader2 } from 'lucide-react';
+
+export function DownloadTravelerPdfButton({
+  jobId,
+  jobNumber,
+}: {
+  jobId: number;
+  jobNumber: string;
+}) {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  async function handleDownload() {
+    setIsDownloading(true);
+
+    try {
+      const response = await fetch(`/api/jobs/${jobId}/traveler-pdf`);
+
+      if (!response.ok) {
+        throw new Error('Failed to generate PDF');
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${jobNumber}-traveler.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      window.alert('Could not download the traveler PDF. Please try again.');
+    } finally {
+      setIsDownloading(false);
+    }
+  }
+
+  return (
+    <Button type="button" variant="outline" onClick={handleDownload} disabled={isDownloading}>
+      {isDownloading ? (
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+      ) : (
+        <Download className="mr-2 h-4 w-4" />
+      )}
+      Download Traveler PDF
+    </Button>
+  );
+}

--- a/app/(dashboard)/dashboard/jobs/[id]/job-inspection-records.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/job-inspection-records.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useActionState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Loader2, PlusCircle } from 'lucide-react';
+import { InspectionRecord, JobOperation } from '@/lib/db/schema';
+import { createInspectionRecord } from '../actions';
+
+type ActionState = {
+  error?: string;
+};
+
+function formatDateTime(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleString();
+}
+
+function formatOperation(
+  operationId: number | null,
+  operations: JobOperation[]
+) {
+  if (!operationId) return '—';
+  const operation = operations.find((op) => op.id === operationId);
+  if (!operation) return '—';
+  return `${operation.sequence}. ${operation.description || '—'}`;
+}
+
+export function JobInspectionRecords({
+  jobId,
+  operations,
+  records
+}: {
+  jobId: number;
+  operations: JobOperation[];
+  records: InspectionRecord[];
+}) {
+  const [createState, createAction, isCreatePending] = useActionState<
+    ActionState,
+    FormData
+  >(createInspectionRecord, {});
+
+  return (
+    <div className="space-y-8 mt-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Inspection Records</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {records.length === 0 ? (
+            <p className="text-muted-foreground">No inspection records yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-3 pr-4 font-medium">Dimension</th>
+                    <th className="pb-3 pr-4 font-medium">Nominal Spec</th>
+                    <th className="pb-3 pr-4 font-medium">Actual Value</th>
+                    <th className="pb-3 pr-4 font-medium">Result</th>
+                    <th className="pb-3 pr-4 font-medium">Operation</th>
+                    <th className="pb-3 pr-4 font-medium">Inspector</th>
+                    <th className="pb-3 font-medium">Inspected At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {records.map((record) => (
+                    <tr key={record.id} className="border-b last:border-b-0">
+                      <td className="py-3 pr-4 font-medium">
+                        {record.dimension || '—'}
+                      </td>
+                      <td className="py-3 pr-4">{record.nominalSpec || '—'}</td>
+                      <td className="py-3 pr-4">{record.actualValue || '—'}</td>
+                      <td className="py-3 pr-4 capitalize">
+                        {record.result || '—'}
+                      </td>
+                      <td className="py-3 pr-4">
+                        {formatOperation(record.operationId, operations)}
+                      </td>
+                      <td className="py-3 pr-4">{record.inspector || '—'}</td>
+                      <td className="py-3">
+                        {formatDateTime(record.inspectedAt)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Inspection Record</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={createAction} className="space-y-4">
+            <input type="hidden" name="jobId" value={jobId} />
+            <div>
+              <Label htmlFor="dimension" className="mb-2">
+                Dimension
+              </Label>
+              <Input
+                id="dimension"
+                name="dimension"
+                placeholder="What was measured"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="nominalSpec" className="mb-2">
+                Nominal Spec
+              </Label>
+              <Input
+                id="nominalSpec"
+                name="nominalSpec"
+                placeholder="Enter nominal spec"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="actualValue" className="mb-2">
+                Actual Value
+              </Label>
+              <Input
+                id="actualValue"
+                name="actualValue"
+                placeholder="Enter actual value"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="result" className="mb-2">
+                Result
+              </Label>
+              <select
+                id="result"
+                name="result"
+                required
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="">Select result</option>
+                <option value="pass">Pass</option>
+                <option value="fail">Fail</option>
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="operationId" className="mb-2">
+                Operation (optional)
+              </Label>
+              <select
+                id="operationId"
+                name="operationId"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="">None</option>
+                {operations.map((operation) => (
+                  <option key={operation.id} value={operation.id}>
+                    {operation.sequence}. {operation.description || '—'}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="inspector" className="mb-2">
+                Inspector
+              </Label>
+              <Input
+                id="inspector"
+                name="inspector"
+                placeholder="Enter inspector name"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="inspectedAt" className="mb-2">
+                Inspected At
+              </Label>
+              <Input
+                id="inspectedAt"
+                name="inspectedAt"
+                type="datetime-local"
+                required
+              />
+            </div>
+            {createState?.error && (
+              <p className="text-red-500 text-sm">{createState.error}</p>
+            )}
+            <Button
+              type="submit"
+              className="bg-orange-500 hover:bg-orange-600 text-white"
+              disabled={isCreatePending}
+            >
+              {isCreatePending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Adding...
+                </>
+              ) : (
+                <>
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  Add Inspection Record
+                </>
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/jobs/[id]/job-operations.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/job-operations.tsx
@@ -18,6 +18,57 @@ function formatDateTime(date: Date | null) {
   return new Date(date).toLocaleString();
 }
 
+function OperationRow({
+  jobId,
+  operation
+}: {
+  jobId: number;
+  operation: JobOperation;
+}) {
+  const [completeState, completeAction, isCompletePending] = useActionState<
+    ActionState,
+    FormData
+  >(completeJobOperation, {});
+
+  return (
+    <li className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 border-b pb-4 last:border-b-0 last:pb-0">
+      <div>
+        <p className="font-medium">
+          {operation.sequence}. {operation.description || '—'}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Machine: {operation.machine || '—'}
+        </p>
+        {operation.completedAt ? (
+          <p className="text-sm text-muted-foreground">
+            Completed by {operation.completedBy || '—'} on{' '}
+            {formatDateTime(operation.completedAt)}
+          </p>
+        ) : null}
+      </div>
+      {!operation.completedAt ? (
+        <div className="flex flex-col items-start gap-2">
+          <form action={completeAction}>
+            <input type="hidden" name="jobId" value={jobId} />
+            <input type="hidden" name="operationId" value={operation.id} />
+            <Button
+              type="submit"
+              variant="outline"
+              size="sm"
+              disabled={isCompletePending}
+            >
+              {isCompletePending ? 'Completing...' : 'Mark Complete'}
+            </Button>
+          </form>
+          {completeState?.error ? (
+            <p className="text-red-500 text-sm">{completeState.error}</p>
+          ) : null}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
 export function JobOperations({
   jobId,
   operations
@@ -29,11 +80,6 @@ export function JobOperations({
     ActionState,
     FormData
   >(createJobOperation, {});
-
-  const [completeState, completeAction, isCompletePending] = useActionState<
-    ActionState,
-    FormData
-  >(completeJobOperation, {});
 
   return (
     <div className="space-y-8 mt-8">
@@ -47,48 +93,13 @@ export function JobOperations({
           ) : (
             <ul className="space-y-4">
               {operations.map((operation) => (
-                <li
+                <OperationRow
                   key={operation.id}
-                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 border-b pb-4 last:border-b-0 last:pb-0"
-                >
-                  <div>
-                    <p className="font-medium">
-                      {operation.sequence}. {operation.description || '—'}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      Machine: {operation.machine || '—'}
-                    </p>
-                    {operation.completedAt ? (
-                      <p className="text-sm text-muted-foreground">
-                        Completed by {operation.completedBy || '—'} on{' '}
-                        {formatDateTime(operation.completedAt)}
-                      </p>
-                    ) : null}
-                  </div>
-                  {!operation.completedAt ? (
-                    <form action={completeAction}>
-                      <input type="hidden" name="jobId" value={jobId} />
-                      <input
-                        type="hidden"
-                        name="operationId"
-                        value={operation.id}
-                      />
-                      <Button
-                        type="submit"
-                        variant="outline"
-                        size="sm"
-                        disabled={isCompletePending}
-                      >
-                        {isCompletePending ? 'Completing...' : 'Mark Complete'}
-                      </Button>
-                    </form>
-                  ) : null}
-                </li>
+                  jobId={jobId}
+                  operation={operation}
+                />
               ))}
             </ul>
-          )}
-          {completeState?.error && (
-            <p className="text-red-500 mt-4">{completeState.error}</p>
           )}
         </CardContent>
       </Card>

--- a/app/(dashboard)/dashboard/jobs/[id]/job-operations.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/job-operations.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useActionState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Loader2, PlusCircle } from 'lucide-react';
+import { JobOperation } from '@/lib/db/schema';
+import { completeJobOperation, createJobOperation } from '../actions';
+
+type ActionState = {
+  error?: string;
+};
+
+function formatDateTime(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleString();
+}
+
+export function JobOperations({
+  jobId,
+  operations
+}: {
+  jobId: number;
+  operations: JobOperation[];
+}) {
+  const [createState, createAction, isCreatePending] = useActionState<
+    ActionState,
+    FormData
+  >(createJobOperation, {});
+
+  const [completeState, completeAction, isCompletePending] = useActionState<
+    ActionState,
+    FormData
+  >(completeJobOperation, {});
+
+  return (
+    <div className="space-y-8 mt-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Operations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {operations.length === 0 ? (
+            <p className="text-muted-foreground">No operations yet.</p>
+          ) : (
+            <ul className="space-y-4">
+              {operations.map((operation) => (
+                <li
+                  key={operation.id}
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 border-b pb-4 last:border-b-0 last:pb-0"
+                >
+                  <div>
+                    <p className="font-medium">
+                      {operation.sequence}. {operation.description || '—'}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Machine: {operation.machine || '—'}
+                    </p>
+                    {operation.completedAt ? (
+                      <p className="text-sm text-muted-foreground">
+                        Completed by {operation.completedBy || '—'} on{' '}
+                        {formatDateTime(operation.completedAt)}
+                      </p>
+                    ) : null}
+                  </div>
+                  {!operation.completedAt ? (
+                    <form action={completeAction}>
+                      <input type="hidden" name="jobId" value={jobId} />
+                      <input
+                        type="hidden"
+                        name="operationId"
+                        value={operation.id}
+                      />
+                      <Button
+                        type="submit"
+                        variant="outline"
+                        size="sm"
+                        disabled={isCompletePending}
+                      >
+                        {isCompletePending ? 'Completing...' : 'Mark Complete'}
+                      </Button>
+                    </form>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+          {completeState?.error && (
+            <p className="text-red-500 mt-4">{completeState.error}</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Operation</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={createAction} className="space-y-4">
+            <input type="hidden" name="jobId" value={jobId} />
+            <div>
+              <Label htmlFor="sequence" className="mb-2">
+                Sequence
+              </Label>
+              <Input
+                id="sequence"
+                name="sequence"
+                type="number"
+                min="1"
+                placeholder="Enter sequence"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="description" className="mb-2">
+                Description
+              </Label>
+              <Input
+                id="description"
+                name="description"
+                placeholder="Enter description"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="machine" className="mb-2">
+                Machine
+              </Label>
+              <Input
+                id="machine"
+                name="machine"
+                placeholder="Enter machine"
+                required
+              />
+            </div>
+            {createState?.error && (
+              <p className="text-red-500 text-sm">{createState.error}</p>
+            )}
+            <Button
+              type="submit"
+              className="bg-orange-500 hover:bg-orange-600 text-white"
+              disabled={isCreatePending}
+            >
+              {isCreatePending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Adding...
+                </>
+              ) : (
+                <>
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  Add Operation
+                </>
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/jobs/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/page.tsx
@@ -2,9 +2,10 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { getJobForTeam, getJobOperationsForTeam } from '@/lib/db/queries';
+import { getJobForTeam, getInspectionRecordsForTeam, getJobOperationsForTeam } from '@/lib/db/queries';
 import { ArrowLeft } from 'lucide-react';
 import { JobOperations } from './job-operations';
+import { JobInspectionRecords } from './job-inspection-records';
 
 function formatDate(date: Date | null) {
   if (!date) return '—';
@@ -30,6 +31,7 @@ export default async function JobDetailPage({
   }
 
   const operations = (await getJobOperationsForTeam(jobId)) ?? [];
+  const inspectionRecords = (await getInspectionRecordsForTeam(jobId)) ?? [];
 
   return (
     <section className="flex-1 p-4 lg:p-8">
@@ -88,6 +90,12 @@ export default async function JobDetailPage({
       </Card>
 
       <JobOperations jobId={jobId} operations={operations} />
+
+      <JobInspectionRecords
+        jobId={jobId}
+        operations={operations}
+        records={inspectionRecords}
+      />
     </section>
   );
 }

--- a/app/(dashboard)/dashboard/jobs/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/page.tsx
@@ -2,8 +2,9 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { getJobForTeam } from '@/lib/db/queries';
+import { getJobForTeam, getJobOperationsForTeam } from '@/lib/db/queries';
 import { ArrowLeft } from 'lucide-react';
+import { JobOperations } from './job-operations';
 
 function formatDate(date: Date | null) {
   if (!date) return '—';
@@ -27,6 +28,8 @@ export default async function JobDetailPage({
   if (!job) {
     notFound();
   }
+
+  const operations = (await getJobOperationsForTeam(jobId)) ?? [];
 
   return (
     <section className="flex-1 p-4 lg:p-8">
@@ -83,6 +86,8 @@ export default async function JobDetailPage({
           </dl>
         </CardContent>
       </Card>
+
+      <JobOperations jobId={jobId} operations={operations} />
     </section>
   );
 }

--- a/app/(dashboard)/dashboard/jobs/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getJobForTeam, getInspectionRecordsForTeam, getJobOperationsForTeam } f
 import { ArrowLeft } from 'lucide-react';
 import { JobOperations } from './job-operations';
 import { JobInspectionRecords } from './job-inspection-records';
+import { DownloadTravelerPdfButton } from './download-traveler-pdf';
 
 function formatDate(date: Date | null) {
   if (!date) return '—';
@@ -42,9 +43,12 @@ export default async function JobDetailPage({
             Back to Jobs
           </Link>
         </Button>
-        <h1 className="text-lg lg:text-2xl font-medium text-gray-900">
-          {job.jobNumber}
-        </h1>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-lg lg:text-2xl font-medium text-gray-900">
+            {job.jobNumber}
+          </h1>
+          <DownloadTravelerPdfButton jobId={jobId} jobNumber={job.jobNumber} />
+        </div>
       </div>
 
       <Card>

--- a/app/(dashboard)/dashboard/jobs/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/jobs/[id]/page.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getJobForTeam } from '@/lib/db/queries';
+import { ArrowLeft } from 'lucide-react';
+
+function formatDate(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleDateString();
+}
+
+export default async function JobDetailPage({
+  params
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const jobId = parseInt(id, 10);
+
+  if (isNaN(jobId)) {
+    notFound();
+  }
+
+  const job = await getJobForTeam(jobId);
+
+  if (!job) {
+    notFound();
+  }
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="mb-6">
+        <Button variant="ghost" asChild className="mb-4 -ml-3">
+          <Link href="/dashboard/jobs">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Jobs
+          </Link>
+        </Button>
+        <h1 className="text-lg lg:text-2xl font-medium text-gray-900">
+          {job.jobNumber}
+        </h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Job Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <dt className="text-sm text-muted-foreground">Job Number</dt>
+              <dd className="font-medium">{job.jobNumber}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Status</dt>
+              <dd className="font-medium capitalize">{job.status}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Customer Name</dt>
+              <dd className="font-medium">{job.customerName || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Part Number</dt>
+              <dd className="font-medium">{job.partNumber || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Part Revision</dt>
+              <dd className="font-medium">{job.partRevision || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Quantity</dt>
+              <dd className="font-medium">{job.quantity ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Due Date</dt>
+              <dd className="font-medium">{formatDate(job.dueDate)}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-muted-foreground">Created</dt>
+              <dd className="font-medium">{formatDate(job.createdAt)}</dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/jobs/actions.ts
+++ b/app/(dashboard)/dashboard/jobs/actions.ts
@@ -4,8 +4,10 @@ import { z } from 'zod';
 import { and, eq } from 'drizzle-orm';
 import { db } from '@/lib/db/drizzle';
 import {
+  inspectionRecords,
   jobOperations,
   jobs,
+  type NewInspectionRecord,
   type NewJob,
   type NewJobOperation
 } from '@/lib/db/schema';
@@ -133,6 +135,74 @@ export const completeJobOperation = validatedActionWithUser(
         completedAt: new Date()
       })
       .where(eq(jobOperations.id, data.operationId));
+
+    redirect(`/dashboard/jobs/${data.jobId}`);
+  }
+);
+
+const createInspectionRecordSchema = z.object({
+  jobId: z.coerce.number().int().positive(),
+  operationId: z
+    .union([z.literal(''), z.coerce.number().int().positive()])
+    .optional(),
+  dimension: z.string().min(1, 'Dimension is required').max(255),
+  nominalSpec: z.string().min(1, 'Nominal spec is required').max(255),
+  actualValue: z.string().min(1, 'Actual value is required').max(255),
+  result: z.enum(['pass', 'fail']),
+  inspector: z.string().min(1, 'Inspector is required').max(255),
+  inspectedAt: z.string().min(1, 'Inspected at is required')
+});
+
+export const createInspectionRecord = validatedActionWithUser(
+  createInspectionRecordSchema,
+  async (data) => {
+    const job = await getJobForTeam(data.jobId);
+
+    if (!job) {
+      return { error: 'Job not found' };
+    }
+
+    const operationId =
+      data.operationId === '' || data.operationId === undefined
+        ? null
+        : data.operationId;
+
+    if (operationId) {
+      const result = await db
+        .select()
+        .from(jobOperations)
+        .where(
+          and(
+            eq(jobOperations.id, operationId),
+            eq(jobOperations.jobId, data.jobId)
+          )
+        )
+        .limit(1);
+
+      if (!result[0]) {
+        return { error: 'Operation not found' };
+      }
+    }
+
+    const newRecord: NewInspectionRecord = {
+      jobId: data.jobId,
+      operationId,
+      dimension: data.dimension,
+      nominalSpec: data.nominalSpec,
+      actualValue: data.actualValue,
+      result: data.result,
+      inspector: data.inspector,
+      inspectedAt: new Date(data.inspectedAt)
+    };
+
+    const [createdRecord] = await db
+      .insert(inspectionRecords)
+      .values(newRecord)
+      .returning();
+
+    if (!createdRecord) {
+      return { error: 'Failed to create inspection record. Please try again.' };
+    }
 
     redirect(`/dashboard/jobs/${data.jobId}`);
   }

--- a/app/(dashboard)/dashboard/jobs/actions.ts
+++ b/app/(dashboard)/dashboard/jobs/actions.ts
@@ -1,9 +1,15 @@
 'use server';
 
 import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
 import { db } from '@/lib/db/drizzle';
-import { jobs, type NewJob } from '@/lib/db/schema';
-import { getUserWithTeam } from '@/lib/db/queries';
+import {
+  jobOperations,
+  jobs,
+  type NewJob,
+  type NewJobOperation
+} from '@/lib/db/schema';
+import { getJobForTeam, getUserWithTeam } from '@/lib/db/queries';
 import { validatedActionWithUser } from '@/lib/auth/middleware';
 import { redirect } from 'next/navigation';
 
@@ -46,5 +52,88 @@ export const createJob = validatedActionWithUser(
     }
 
     redirect(`/dashboard/jobs/${createdJob.id}`);
+  }
+);
+
+const createJobOperationSchema = z.object({
+  jobId: z.coerce.number().int().positive(),
+  sequence: z.coerce.number().int().positive(),
+  description: z.string().min(1, 'Description is required').max(255),
+  machine: z.string().min(1, 'Machine is required').max(255)
+});
+
+export const createJobOperation = validatedActionWithUser(
+  createJobOperationSchema,
+  async (data) => {
+    const job = await getJobForTeam(data.jobId);
+
+    if (!job) {
+      return { error: 'Job not found' };
+    }
+
+    const newOperation: NewJobOperation = {
+      jobId: data.jobId,
+      sequence: data.sequence,
+      description: data.description,
+      machine: data.machine
+    };
+
+    const [createdOperation] = await db
+      .insert(jobOperations)
+      .values(newOperation)
+      .returning();
+
+    if (!createdOperation) {
+      return { error: 'Failed to create operation. Please try again.' };
+    }
+
+    redirect(`/dashboard/jobs/${data.jobId}`);
+  }
+);
+
+const completeJobOperationSchema = z.object({
+  jobId: z.coerce.number().int().positive(),
+  operationId: z.coerce.number().int().positive()
+});
+
+export const completeJobOperation = validatedActionWithUser(
+  completeJobOperationSchema,
+  async (data, _, user) => {
+    const job = await getJobForTeam(data.jobId);
+
+    if (!job) {
+      return { error: 'Job not found' };
+    }
+
+    const result = await db
+      .select()
+      .from(jobOperations)
+      .where(
+        and(
+          eq(jobOperations.id, data.operationId),
+          eq(jobOperations.jobId, data.jobId)
+        )
+      )
+      .limit(1);
+
+    const operation = result[0];
+
+    if (!operation) {
+      return { error: 'Operation not found' };
+    }
+
+    if (operation.completedAt) {
+      return { error: 'Operation is already completed' };
+    }
+
+    await db
+      .update(jobOperations)
+      .set({
+        completedBy: user.name || user.email,
+        completedAt: new Date()
+      })
+      .where(eq(jobOperations.id, data.operationId));
+
+    redirect(`/dashboard/jobs/${data.jobId}`);
   }
 );

--- a/app/(dashboard)/dashboard/jobs/actions.ts
+++ b/app/(dashboard)/dashboard/jobs/actions.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { z } from 'zod';
+import { db } from '@/lib/db/drizzle';
+import { jobs, type NewJob } from '@/lib/db/schema';
+import { getUserWithTeam } from '@/lib/db/queries';
+import { validatedActionWithUser } from '@/lib/auth/middleware';
+import { redirect } from 'next/navigation';
+
+const createJobSchema = z.object({
+  jobNumber: z.string().min(1, 'Job number is required').max(255),
+  customerName: z.string().max(255).optional(),
+  partNumber: z.string().max(255).optional(),
+  partRevision: z.string().max(255).optional(),
+  quantity: z
+    .union([z.literal(''), z.coerce.number().int().positive()])
+    .optional(),
+  dueDate: z.string().optional()
+});
+
+export const createJob = validatedActionWithUser(
+  createJobSchema,
+  async (data, _, user) => {
+    const userWithTeam = await getUserWithTeam(user.id);
+
+    if (!userWithTeam?.teamId) {
+      return { error: 'User is not part of a team' };
+    }
+
+    const newJob: NewJob = {
+      teamId: userWithTeam.teamId,
+      jobNumber: data.jobNumber,
+      customerName: data.customerName || null,
+      partNumber: data.partNumber || null,
+      partRevision: data.partRevision || null,
+      quantity: data.quantity === '' || data.quantity === undefined
+        ? null
+        : data.quantity,
+      dueDate: data.dueDate ? new Date(data.dueDate) : null
+    };
+
+    const [createdJob] = await db.insert(jobs).values(newJob).returning();
+
+    if (!createdJob) {
+      return { error: 'Failed to create job. Please try again.' };
+    }
+
+    redirect(`/dashboard/jobs/${createdJob.id}`);
+  }
+);

--- a/app/(dashboard)/dashboard/jobs/new/page.tsx
+++ b/app/(dashboard)/dashboard/jobs/new/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import Link from 'next/link';
+import { useActionState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Loader2, PlusCircle } from 'lucide-react';
+import { createJob } from '../actions';
+
+type ActionState = {
+  error?: string;
+};
+
+export default function NewJobPage() {
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    createJob,
+    {}
+  );
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <h1 className="text-lg lg:text-2xl font-medium text-gray-900 mb-6">
+        New Job
+      </h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Job Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" action={formAction}>
+            <div>
+              <Label htmlFor="jobNumber" className="mb-2">
+                Job Number
+              </Label>
+              <Input
+                id="jobNumber"
+                name="jobNumber"
+                placeholder="Enter job number"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="customerName" className="mb-2">
+                Customer Name
+              </Label>
+              <Input
+                id="customerName"
+                name="customerName"
+                placeholder="Enter customer name"
+              />
+            </div>
+            <div>
+              <Label htmlFor="partNumber" className="mb-2">
+                Part Number
+              </Label>
+              <Input
+                id="partNumber"
+                name="partNumber"
+                placeholder="Enter part number"
+              />
+            </div>
+            <div>
+              <Label htmlFor="partRevision" className="mb-2">
+                Part Revision
+              </Label>
+              <Input
+                id="partRevision"
+                name="partRevision"
+                placeholder="Enter part revision"
+              />
+            </div>
+            <div>
+              <Label htmlFor="quantity" className="mb-2">
+                Quantity
+              </Label>
+              <Input
+                id="quantity"
+                name="quantity"
+                type="number"
+                min="1"
+                placeholder="Enter quantity"
+              />
+            </div>
+            <div>
+              <Label htmlFor="dueDate" className="mb-2">
+                Due Date
+              </Label>
+              <Input id="dueDate" name="dueDate" type="date" />
+            </div>
+            {state.error && (
+              <p className="text-red-500 text-sm">{state.error}</p>
+            )}
+            <div className="flex gap-3">
+              <Button
+                type="submit"
+                className="bg-orange-500 hover:bg-orange-600 text-white"
+                disabled={isPending}
+              >
+                {isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  <>
+                    <PlusCircle className="mr-2 h-4 w-4" />
+                    Create Job
+                  </>
+                )}
+              </Button>
+              <Button type="button" variant="outline" asChild>
+                <Link href="/dashboard/jobs">Cancel</Link>
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/jobs/page.tsx
+++ b/app/(dashboard)/dashboard/jobs/page.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getJobsForTeam } from '@/lib/db/queries';
+import { Briefcase, PlusCircle } from 'lucide-react';
+
+function formatDate(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleDateString();
+}
+
+export default async function JobsPage() {
+  const jobsList = await getJobsForTeam();
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium text-gray-900">Jobs</h1>
+        <Button
+          asChild
+          className="bg-orange-500 hover:bg-orange-600 text-white"
+        >
+          <Link href="/dashboard/jobs/new">
+            <PlusCircle className="mr-2 h-4 w-4" />
+            New Job
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Jobs</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {jobsList.length > 0 ? (
+            <ul className="space-y-4">
+              {jobsList.map((job) => (
+                <li
+                  key={job.id}
+                  className="flex items-center justify-between border-b border-gray-100 pb-4 last:border-0 last:pb-0"
+                >
+                  <div>
+                    <Link
+                      href={`/dashboard/jobs/${job.id}`}
+                      className="font-medium text-gray-900 hover:text-orange-600"
+                    >
+                      {job.jobNumber}
+                    </Link>
+                    {job.customerName && (
+                      <p className="text-sm text-muted-foreground">
+                        {job.customerName}
+                      </p>
+                    )}
+                  </div>
+                  <div className="text-right text-sm">
+                    <p className="capitalize text-gray-900">{job.status}</p>
+                    <p className="text-muted-foreground">
+                      Due {formatDate(job.dueDate)}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="flex flex-col items-center justify-center text-center py-12">
+              <Briefcase className="h-12 w-12 text-orange-500 mb-4" />
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                No jobs yet
+              </h3>
+              <p className="text-sm text-gray-500 max-w-sm mb-4">
+                Create your first job to start tracking work for your team.
+              </p>
+              <Button
+                asChild
+                className="bg-orange-500 hover:bg-orange-600 text-white"
+              >
+                <Link href="/dashboard/jobs/new">
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  New Job
+                </Link>
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/layout.tsx
+++ b/app/(dashboard)/dashboard/layout.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Users, Settings, Shield, Activity, Menu } from 'lucide-react';
+import { Users, Settings, Shield, Activity, Menu, Briefcase } from 'lucide-react';
 
 export default function DashboardLayout({
   children
@@ -15,6 +15,7 @@ export default function DashboardLayout({
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   const navItems = [
+    { href: '/dashboard/jobs', icon: Briefcase, label: 'Jobs' },
     { href: '/dashboard', icon: Users, label: 'Team' },
     { href: '/dashboard/general', icon: Settings, label: 'General' },
     { href: '/dashboard/activity', icon: Activity, label: 'Activity' },
@@ -48,12 +49,18 @@ export default function DashboardLayout({
           }`}
         >
           <nav className="h-full overflow-y-auto p-4">
-            {navItems.map((item) => (
+            {navItems.map((item) => {
+              const isActive =
+                item.href === '/dashboard/jobs'
+                  ? pathname.startsWith('/dashboard/jobs')
+                  : pathname === item.href;
+
+              return (
               <Link key={item.href} href={item.href} passHref>
                 <Button
-                  variant={pathname === item.href ? 'secondary' : 'ghost'}
+                  variant={isActive ? 'secondary' : 'ghost'}
                   className={`shadow-none my-1 w-full justify-start ${
-                    pathname === item.href ? 'bg-gray-100' : ''
+                    isActive ? 'bg-gray-100' : ''
                   }`}
                   onClick={() => setIsSidebarOpen(false)}
                 >
@@ -61,7 +68,8 @@ export default function DashboardLayout({
                   {item.label}
                 </Button>
               </Link>
-            ))}
+              );
+            })}
           </nav>
         </aside>
 

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -84,7 +84,7 @@ function Header() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
         <Link href="/" className="flex items-center">
           <CircleIcon className="h-6 w-6 text-orange-500" />
-          <span className="ml-2 text-xl font-semibold text-gray-900">ACME</span>
+          <span className="ml-2 text-xl font-semibold text-gray-900">OpsTrace</span>
         </Link>
         <div className="flex items-center space-x-4">
           <Suspense fallback={<div className="h-9" />}>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -10,13 +10,13 @@ export default function HomePage() {
           <div className="lg:grid lg:grid-cols-12 lg:gap-8">
             <div className="sm:text-center md:max-w-2xl md:mx-auto lg:col-span-6 lg:text-left">
               <h1 className="text-4xl font-bold text-gray-900 tracking-tight sm:text-5xl md:text-6xl">
-                Build Your SaaS
+                Build Your Job Travelers
                 <span className="block text-orange-500">Faster Than Ever</span>
               </h1>
               <p className="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">
-                Launch your SaaS product in record time with our powerful,
-                ready-to-use template. Packed with modern technologies and
-                essential integrations.
+                OpsTrace helps machine shops track parts through production with
+                digital inspection sign-offs for defense, aerospace, and medical
+                compliance audits.
               </p>
               <div className="mt-8 sm:max-w-lg sm:mx-auto sm:text-center lg:text-left lg:mx-0">
                 <a
@@ -28,7 +28,7 @@ export default function HomePage() {
                     variant="outline"
                     className="text-lg rounded-full"
                   >
-                    Deploy your own
+                    Get Started
                     <ArrowRight className="ml-2 h-5 w-5" />
                   </Button>
                 </a>
@@ -55,11 +55,11 @@ export default function HomePage() {
               </div>
               <div className="mt-5">
                 <h2 className="text-lg font-medium text-gray-900">
-                  Next.js and React
+                  Digital Job Travelers
                 </h2>
                 <p className="mt-2 text-base text-gray-500">
-                  Leverage the power of modern web technologies for optimal
-                  performance and developer experience.
+                  Create and manage job travelers for every part that goes
+                  through your shop.
                 </p>
               </div>
             </div>
@@ -70,11 +70,11 @@ export default function HomePage() {
               </div>
               <div className="mt-5">
                 <h2 className="text-lg font-medium text-gray-900">
-                  Postgres and Drizzle ORM
+                  Inspection Sign-Offs
                 </h2>
                 <p className="mt-2 text-base text-gray-500">
-                  Robust database solution with an intuitive ORM for efficient
-                  data management and scalability.
+                  Record pass/fail results for every operation with inspector
+                  signatures and timestamps.
                 </p>
               </div>
             </div>
@@ -85,11 +85,11 @@ export default function HomePage() {
               </div>
               <div className="mt-5">
                 <h2 className="text-lg font-medium text-gray-900">
-                  Stripe Integration
+                  PDF Export
                 </h2>
                 <p className="mt-2 text-base text-gray-500">
-                  Seamless payment processing and subscription management with
-                  industry-leading Stripe integration.
+                  Generate print-ready PDFs for auditors — complete with
+                  operations, inspections, and sign-offs.
                 </p>
               </div>
             </div>
@@ -102,22 +102,22 @@ export default function HomePage() {
           <div className="lg:grid lg:grid-cols-2 lg:gap-8 lg:items-center">
             <div>
               <h2 className="text-3xl font-bold text-gray-900 sm:text-4xl">
-                Ready to launch your SaaS?
+                Ready to go paperless?
               </h2>
               <p className="mt-3 max-w-3xl text-lg text-gray-500">
-                Our template provides everything you need to get your SaaS up
-                and running quickly. Don't waste time on boilerplate - focus on
-                what makes your product unique.
+                Replace paper job travelers with digital inspection records your
+                auditors can trust. OpsTrace helps your shop track every part
+                through production and stay audit-ready.
               </p>
             </div>
             <div className="mt-8 lg:mt-0 flex justify-center lg:justify-end">
-              <a href="https://github.com/nextjs/saas-starter" target="_blank">
+              <a href="/sign-up">
                 <Button
                   size="lg"
                   variant="outline"
                   className="text-lg rounded-full"
                 >
-                  View the code
+                  Get Started
                   <ArrowRight className="ml-3 h-6 w-6" />
                 </Button>
               </a>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,0 +1,260 @@
+import { Button } from '@/components/ui/button';
+import {
+  Check,
+  ClipboardCheck,
+  ClipboardList,
+  Download,
+  ShieldCheck,
+  Smartphone,
+  Users
+} from 'lucide-react';
+
+const complianceBadges = [
+  'AS9100D',
+  'ISO 13485',
+  'ITAR',
+  'CMMC L1',
+  'FAR/DFARS',
+  'ISO 9001'
+];
+
+const features = [
+  {
+    icon: ClipboardList,
+    title: 'Digital Job Travelers',
+    description:
+      'Replace paper travelers with structured digital records for every part — operations, quantities, and revision history in one place.'
+  },
+  {
+    icon: ClipboardCheck,
+    title: 'Inspection Sign-offs',
+    description:
+      'Capture pass/fail results, inspector identity, and timestamps at each operation. No more illegible signatures on clipboards.'
+  },
+  {
+    icon: Download,
+    title: 'One-Click PDF Export',
+    description:
+      'Generate print-ready traveler PDFs on demand — complete with operations, inspections, and sign-offs for auditors.'
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Audit-Ready Records',
+    description:
+      'Tamper-evident revision history and complete traceability from job open to archive. Built for AS9100, ISO 13485, and ITAR audits.'
+  },
+  {
+    icon: Users,
+    title: 'Team Scoping',
+    description:
+      'Separate data by team or program so contract work stays isolated. Operators see only the jobs they need on the floor.'
+  },
+  {
+    icon: Smartphone,
+    title: 'Works on the Shop Floor',
+    description:
+      'Sign off inspections from a tablet or phone at the machine. No desktop required — works where your operators actually work.'
+  }
+];
+
+const steps = [
+  {
+    number: '01',
+    title: 'Open a job',
+    description:
+      'Create a digital traveler with part number, revision, and routing — or import from your existing workflow.'
+  },
+  {
+    number: '02',
+    title: 'Add operations',
+    description:
+      'Define each operation in sequence with work centers, specs, and inspection requirements.'
+  },
+  {
+    number: '03',
+    title: 'Sign off as work completes',
+    description:
+      'Operators and inspectors record completion and pass/fail results with timestamps at the machine.'
+  },
+  {
+    number: '04',
+    title: 'Export and archive',
+    description:
+      'One-click PDF export gives auditors a complete, tamper-evident paper trail — ready when they ask.'
+  }
+];
+
+function HeroButtons({ className }: { className?: string }) {
+  return (
+    <div className={className}>
+      <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+        <a href="/sign-up">
+          <Button
+            size="lg"
+            className="w-full sm:w-auto bg-orange-600 hover:bg-orange-700 text-white"
+          >
+            Start Free Trial
+          </Button>
+        </a>
+        <a href="/pricing">
+          <Button size="lg" variant="outline" className="w-full sm:w-auto">
+            View Pricing
+          </Button>
+        </a>
+      </div>
+      <p className="mt-4 text-sm text-gray-500">
+        No credit card required · 14-day free trial
+      </p>
+    </div>
+  );
+}
+
+export default function MarketingPage() {
+  return (
+    <main>
+      {/* HERO */}
+      <section className="py-20 lg:py-28">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-3xl">
+            <span className="inline-flex items-center rounded-full bg-orange-50 px-3 py-1 text-sm font-medium text-orange-700 ring-1 ring-inset ring-orange-600/20">
+              Built for precision machine shops
+            </span>
+            <h1 className="mt-6 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+              Digital Job Travelers. Audit-Ready from Day One.
+            </h1>
+            <p className="mt-6 text-lg text-gray-600 sm:text-xl leading-relaxed">
+              OpsTrace replaces paper travelers with a structured digital
+              record — operations, inspection sign-offs, and revision history
+              — ready for AS9100, ISO 13485, and ITAR compliance audits.
+            </p>
+            <HeroButtons className="mt-10" />
+          </div>
+        </div>
+      </section>
+
+      {/* COMPLIANCE STRIP */}
+      <section className="bg-gray-100 py-10">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="text-center text-sm font-medium text-gray-600 mb-6">
+            Trusted by shops doing defense, aerospace &amp; medical contract
+            work
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            {complianceBadges.map((badge) => (
+              <span
+                key={badge}
+                className="inline-flex items-center gap-1.5 rounded-full bg-white px-4 py-2 text-sm font-medium text-gray-800 shadow-sm ring-1 ring-gray-200"
+              >
+                <Check className="h-4 w-4 text-orange-600 shrink-0" />
+                {badge}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* THE PROBLEM */}
+      <section className="py-20 bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            Paper travelers fail audits. Clipboards lose traceability.
+          </h2>
+          <p className="mt-6 text-lg text-gray-600 leading-relaxed">
+            When an auditor asks for the complete record on a part — every
+            operation, every inspection, every revision — paper travelers
+            fall apart. Signatures get smudged, pages go missing, and there is
+            no tamper-evident history. Shops doing defense, aerospace, and
+            medical contract work need records that prove what was done, who
+            signed off, and when — without scrambling the night before the
+            audit.
+          </p>
+        </div>
+      </section>
+
+      {/* FEATURES GRID */}
+      <section className="py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {features.map((feature) => (
+              <div
+                key={feature.title}
+                className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-200"
+              >
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-orange-600 text-white">
+                  <feature.icon className="h-6 w-6" />
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-gray-900">
+                  {feature.title}
+                </h3>
+                <p className="mt-2 text-base text-gray-600 leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* HOW IT WORKS */}
+      <section className="py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl mb-16">
+            How it works
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10">
+            {steps.map((step) => (
+              <div key={step.number} className="relative">
+                <span className="text-6xl font-bold text-orange-600/20 leading-none">
+                  {step.number}
+                </span>
+                <h3 className="mt-4 text-xl font-semibold text-gray-900">
+                  {step.title}
+                </h3>
+                <p className="mt-3 text-base text-gray-600 leading-relaxed">
+                  {step.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* BOTTOM CTA */}
+      <section className="bg-orange-600 py-20">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Stop hoping the auditor doesn&apos;t ask for the paper trail.
+          </h2>
+          <p className="mt-6 text-lg text-orange-100 leading-relaxed">
+            Replace clipboards with digital travelers your team will actually
+            use on the floor — and records auditors can trust from day one.
+          </p>
+          <div className="mt-10 flex flex-col items-center">
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+              <a href="/sign-up">
+                <Button
+                  size="lg"
+                  className="w-full sm:w-auto bg-white text-orange-600 hover:bg-orange-50"
+                >
+                  Start Free Trial
+                </Button>
+              </a>
+              <a href="/pricing">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="w-full sm:w-auto border-white text-white hover:bg-orange-700 hover:text-white bg-transparent"
+                >
+                  View Pricing
+                </Button>
+              </a>
+            </div>
+            <p className="mt-4 text-sm text-orange-100">
+              No credit card required · 14-day free trial
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,242 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { checkoutAction } from '@/lib/payments/actions';
+import { getStripePrices, getStripeProducts } from '@/lib/payments/stripe';
+import { ArrowRight, CheckCircle2 } from 'lucide-react';
+
+export const metadata = {
+  title: 'Pricing – OpsTrace',
+  description:
+    'Simple pricing for precision machine shops. Digital job travelers with inspection sign-offs, audit-ready records, and PDF export — built for AS9100, ISO 13485, and ITAR compliance.'
+};
+
+const tiers = [
+  {
+    name: 'Shop',
+    price: 299,
+    summary: 'Up to 100 jobs/month · 3 users',
+    highlighted: false,
+    features: [
+      'Up to 100 active jobs per month',
+      'Unlimited operations per job',
+      'Inspection sign-off records',
+      'PDF traveler export',
+      'Audit log (90-day retention)',
+      'Up to 3 team members',
+      'Email support'
+    ]
+  },
+  {
+    name: 'Production',
+    price: 499,
+    summary: 'Unlimited jobs · up to 10 users',
+    highlighted: true,
+    features: [
+      'Unlimited jobs per month',
+      'Unlimited operations per job',
+      'Inspection sign-off records',
+      'PDF traveler export',
+      'Audit log (2-year retention)',
+      'Up to 10 team members',
+      'Role-based access (operator / inspector / manager)',
+      'Priority email support'
+    ]
+  },
+  {
+    name: 'Enterprise',
+    price: 799,
+    summary: 'Unlimited everything',
+    highlighted: false,
+    features: [
+      'Everything in Production',
+      'Unlimited team members',
+      'Unlimited audit log retention',
+      'Custom PDF traveler branding',
+      'CSV/JSON data export',
+      'Dedicated onboarding call',
+      'Priority phone + email support',
+      'SLA guarantee'
+    ]
+  }
+] as const;
+
+const faqs = [
+  {
+    question: 'What counts as a "job"?',
+    answer:
+      'A job is a single work order — one part number, one traveler. Each new work order you open counts toward your monthly job limit.'
+  },
+  {
+    question: 'Can I upgrade or downgrade mid-month?',
+    answer:
+      'Yes. Changes take effect at the start of your next billing cycle. Your data and history are never affected.'
+  },
+  {
+    question: 'Are inspection records locked after sign-off?',
+    answer:
+      'Yes. Once an inspector signs off an operation, the record is locked and timestamped. The sign-off cannot be edited — by design, for audit integrity.'
+  },
+  {
+    question: 'Does OpsTrace support multiple shifts?',
+    answer:
+      'Yes. Every user gets their own login. Each sign-off is attributed to a named individual, so shift hand-offs are fully traceable.'
+  },
+  {
+    question: 'Is my data exportable?',
+    answer:
+      'All plans can export individual job travelers as PDF. The Enterprise plan adds bulk CSV/JSON export for integration with your ERP or QMS.'
+  }
+];
+
+function findPriceIdForTier(
+  tierName: string,
+  products: Awaited<ReturnType<typeof getStripeProducts>>,
+  prices: Awaited<ReturnType<typeof getStripePrices>>
+) {
+  const product = products.find((p) =>
+    p.name.toLowerCase().includes(tierName.toLowerCase())
+  );
+  if (!product) return undefined;
+  return prices.find((price) => price.productId === product.id)?.id;
+}
+
+function TierCta({
+  tierName,
+  priceId
+}: {
+  tierName: string;
+  priceId?: string;
+}) {
+  if (tierName === 'Enterprise') {
+    return (
+      <Button
+        asChild
+        variant="outline"
+        className="w-full border-orange-600 text-orange-600 hover:bg-orange-50"
+      >
+        <Link href="mailto:hello@opstrace.io">
+          Contact Sales
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Link>
+      </Button>
+    );
+  }
+
+  if (priceId) {
+    return (
+      <form action={checkoutAction}>
+        <input type="hidden" name="priceId" value={priceId} />
+        <Button
+          type="submit"
+          className="w-full bg-orange-600 hover:bg-orange-700 text-white"
+        >
+          Start Free Trial
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <Button asChild className="w-full bg-orange-600 hover:bg-orange-700 text-white">
+      <Link href="/sign-up">Start Free Trial</Link>
+    </Button>
+  );
+}
+
+export default async function PricingPage() {
+  let prices: Awaited<ReturnType<typeof getStripePrices>> = [];
+  let products: Awaited<ReturnType<typeof getStripeProducts>> = [];
+
+  try {
+    [prices, products] = await Promise.all([
+      getStripePrices(),
+      getStripeProducts()
+    ]);
+  } catch {
+    // Stripe unavailable — fall back to sign-up links for Shop and Production
+  }
+
+  return (
+    <main className="py-16 lg:py-24">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center max-w-2xl mx-auto mb-16">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Simple pricing for precision shops
+          </h1>
+          <p className="mt-4 text-lg text-gray-600">
+            Digital job travelers with inspection sign-offs and audit-ready
+            records. 14-day free trial on all plans — no credit card required.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
+          {tiers.map((tier) => {
+            const priceId =
+              tier.name === 'Enterprise'
+                ? undefined
+                : findPriceIdForTier(tier.name, products, prices);
+
+            return (
+              <div
+                key={tier.name}
+                className={`relative rounded-2xl bg-white p-8 ${
+                  tier.highlighted
+                    ? 'border border-orange-500 ring-2 ring-orange-500 shadow-xl'
+                    : 'border border-gray-200 shadow-sm'
+                }`}
+              >
+                {tier.highlighted && (
+                  <span className="absolute -top-3 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-orange-600 px-4 py-1 text-sm font-medium text-white">
+                    Most Popular
+                  </span>
+                )}
+
+                <h2 className="text-2xl font-bold text-gray-900">
+                  {tier.name}
+                </h2>
+                <p className="mt-1 text-sm text-gray-500">{tier.summary}</p>
+                <p className="mt-6">
+                  <span className="text-4xl font-bold text-gray-900">
+                    ${tier.price}
+                  </span>
+                  <span className="text-gray-500">/month</span>
+                </p>
+
+                <ul className="mt-8 space-y-3">
+                  {tier.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2">
+                      <CheckCircle2 className="h-5 w-5 text-orange-600 shrink-0 mt-0.5" />
+                      <span className="text-sm text-gray-700">{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-8">
+                  <TierCta tierName={tier.name} priceId={priceId} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <section className="mt-20 pt-16 border-t border-gray-200">
+          <h2 className="text-2xl font-bold text-gray-900 text-center mb-10">
+            Common questions
+          </h2>
+          <dl className="max-w-3xl mx-auto space-y-8">
+            {faqs.map((faq) => (
+              <div key={faq.question}>
+                <dt className="text-lg font-semibold text-gray-900">
+                  {faq.question}
+                </dt>
+                <dd className="mt-2 text-gray-600 leading-relaxed">
+                  {faq.answer}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/api/jobs/[id]/traveler-pdf/route.ts
+++ b/app/api/jobs/[id]/traveler-pdf/route.ts
@@ -1,0 +1,40 @@
+import { notFound } from 'next/navigation';
+import {
+  getInspectionRecordsForTeam,
+  getJobForTeam,
+  getJobOperationsForTeam,
+} from '@/lib/db/queries';
+import { generateJobTravelerPdf } from '@/lib/pdf/job-traveler';
+
+function safeFilename(jobNumber: string) {
+  return jobNumber.replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const jobId = parseInt(id, 10);
+
+  if (isNaN(jobId)) {
+    notFound();
+  }
+
+  const job = await getJobForTeam(jobId);
+  if (!job) {
+    notFound();
+  }
+
+  const operations = (await getJobOperationsForTeam(jobId)) ?? [];
+  const inspectionRecords = (await getInspectionRecordsForTeam(jobId)) ?? [];
+  const pdf = await generateJobTravelerPdf(job, operations, inspectionRecords);
+
+  return new Response(pdf, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="${safeFilename(job.jobNumber)}-traveler.pdf"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,8 +5,9 @@ import { getUser, getTeamForUser } from '@/lib/db/queries';
 import { SWRConfig } from 'swr';
 
 export const metadata: Metadata = {
-  title: 'Next.js SaaS Starter',
-  description: 'Get started quickly with Next.js, Postgres, and Stripe.'
+  title: 'OpsTrace',
+  description:
+    'Digital job travelers for machine shops — track parts through production with inspection sign-offs for compliance audits.'
 };
 
 export const viewport: Viewport = {

--- a/lib/db/migrations/0001_overrated_hex.sql
+++ b/lib/db/migrations/0001_overrated_hex.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "jobs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"team_id" integer NOT NULL,
+	"job_number" varchar(255) NOT NULL,
+	"customer_name" varchar(255),
+	"part_number" varchar(255),
+	"part_revision" varchar(255),
+	"quantity" integer,
+	"due_date" timestamp,
+	"status" varchar(50) DEFAULT 'open' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/0002_magical_prism.sql
+++ b/lib/db/migrations/0002_magical_prism.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "job_operations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"job_id" integer NOT NULL,
+	"sequence" integer NOT NULL,
+	"description" varchar(255),
+	"machine" varchar(255),
+	"completed_by" varchar(255),
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "job_operations" ADD CONSTRAINT "job_operations_job_id_jobs_id_fk" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/0003_opposite_mojo.sql
+++ b/lib/db/migrations/0003_opposite_mojo.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "inspection_records" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"job_id" integer NOT NULL,
+	"operation_id" integer,
+	"dimension" varchar(255),
+	"nominal_spec" varchar(255),
+	"actual_value" varchar(255),
+	"result" varchar(20),
+	"inspector" varchar(255),
+	"inspected_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "inspection_records" ADD CONSTRAINT "inspection_records_job_id_jobs_id_fk" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "inspection_records" ADD CONSTRAINT "inspection_records_operation_id_job_operations_id_fk" FOREIGN KEY ("operation_id") REFERENCES "public"."job_operations"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,503 @@
+{
+  "id": "c3ba57de-b6ff-4baa-9fb7-eca44b4ff52b",
+  "prevId": "261fd993-fb2c-43e7-89d6-cd58786c5f58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_number": {
+          "name": "job_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_number": {
+          "name": "part_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_revision": {
+          "name": "part_revision",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_team_id_teams_id_fk": {
+          "name": "jobs_team_id_teams_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/0002_snapshot.json
+++ b/lib/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,579 @@
+{
+  "id": "07ef9bba-0a85-4d87-8923-6802bb9684ad",
+  "prevId": "c3ba57de-b6ff-4baa-9fb7-eca44b4ff52b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_operations": {
+      "name": "job_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine": {
+          "name": "machine",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_operations_job_id_jobs_id_fk": {
+          "name": "job_operations_job_id_jobs_id_fk",
+          "tableFrom": "job_operations",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_number": {
+          "name": "job_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_number": {
+          "name": "part_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_revision": {
+          "name": "part_revision",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_team_id_teams_id_fk": {
+          "name": "jobs_team_id_teams_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/0003_snapshot.json
+++ b/lib/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,680 @@
+{
+  "id": "5fc14b81-abbf-49b6-b5fd-46bf3cd94f47",
+  "prevId": "07ef9bba-0a85-4d87-8923-6802bb9684ad",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inspection_records": {
+      "name": "inspection_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nominal_spec": {
+          "name": "nominal_spec",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_value": {
+          "name": "actual_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspector": {
+          "name": "inspector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "inspection_records_job_id_jobs_id_fk": {
+          "name": "inspection_records_job_id_jobs_id_fk",
+          "tableFrom": "inspection_records",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_records_operation_id_job_operations_id_fk": {
+          "name": "inspection_records_operation_id_job_operations_id_fk",
+          "tableFrom": "inspection_records",
+          "tableTo": "job_operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_operations": {
+      "name": "job_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine": {
+          "name": "machine",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_operations_job_id_jobs_id_fk": {
+          "name": "job_operations_job_id_jobs_id_fk",
+          "tableFrom": "job_operations",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_number": {
+          "name": "job_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_number": {
+          "name": "part_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_revision": {
+          "name": "part_revision",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_team_id_teams_id_fk": {
+          "name": "jobs_team_id_teams_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1726443359662,
       "tag": "0000_soft_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781770121552,
+      "tag": "0001_overrated_hex",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781770121552,
       "tag": "0001_overrated_hex",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781774375242,
+      "tag": "0002_magical_prism",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781774375242,
       "tag": "0002_magical_prism",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781775660439,
+      "tag": "0003_opposite_mojo",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -1,6 +1,6 @@
 import { desc, and, eq, isNull } from 'drizzle-orm';
 import { db } from './drizzle';
-import { activityLogs, teamMembers, teams, users } from './schema';
+import { activityLogs, jobs, teamMembers, teams, users } from './schema';
 import { cookies } from 'next/headers';
 import { verifyToken } from '@/lib/auth/session';
 
@@ -127,4 +127,32 @@ export async function getTeamForUser() {
   });
 
   return result?.team || null;
+}
+
+export async function getJobsForTeam() {
+  const team = await getTeamForUser();
+  if (!team) {
+    throw new Error('User not authenticated');
+  }
+
+  return await db
+    .select()
+    .from(jobs)
+    .where(eq(jobs.teamId, team.id))
+    .orderBy(desc(jobs.createdAt));
+}
+
+export async function getJobForTeam(jobId: number) {
+  const team = await getTeamForUser();
+  if (!team) {
+    return null;
+  }
+
+  const result = await db
+    .select()
+    .from(jobs)
+    .where(and(eq(jobs.id, jobId), eq(jobs.teamId, team.id)))
+    .limit(1);
+
+  return result.length > 0 ? result[0] : null;
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -1,6 +1,13 @@
-import { desc, and, eq, isNull } from 'drizzle-orm';
+import { asc, desc, and, eq, isNull } from 'drizzle-orm';
 import { db } from './drizzle';
-import { activityLogs, jobs, teamMembers, teams, users } from './schema';
+import {
+  activityLogs,
+  jobOperations,
+  jobs,
+  teamMembers,
+  teams,
+  users
+} from './schema';
 import { cookies } from 'next/headers';
 import { verifyToken } from '@/lib/auth/session';
 
@@ -155,4 +162,17 @@ export async function getJobForTeam(jobId: number) {
     .limit(1);
 
   return result.length > 0 ? result[0] : null;
+}
+
+export async function getJobOperationsForTeam(jobId: number) {
+  const job = await getJobForTeam(jobId);
+  if (!job) {
+    return null;
+  }
+
+  return await db
+    .select()
+    .from(jobOperations)
+    .where(eq(jobOperations.jobId, jobId))
+    .orderBy(asc(jobOperations.sequence));
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -2,6 +2,7 @@ import { asc, desc, and, eq, isNull } from 'drizzle-orm';
 import { db } from './drizzle';
 import {
   activityLogs,
+  inspectionRecords,
   jobOperations,
   jobs,
   teamMembers,
@@ -175,4 +176,17 @@ export async function getJobOperationsForTeam(jobId: number) {
     .from(jobOperations)
     .where(eq(jobOperations.jobId, jobId))
     .orderBy(asc(jobOperations.sequence));
+}
+
+export async function getInspectionRecordsForTeam(jobId: number) {
+  const job = await getJobForTeam(jobId);
+  if (!job) {
+    return null;
+  }
+
+  return await db
+    .select()
+    .from(inspectionRecords)
+    .where(eq(inspectionRecords.jobId, jobId))
+    .orderBy(desc(inspectionRecords.inspectedAt));
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -97,6 +97,21 @@ export const jobOperations = pgTable('job_operations', {
   createdAt: timestamp('created_at').notNull().defaultNow(),
 });
 
+export const inspectionRecords = pgTable('inspection_records', {
+  id: serial('id').primaryKey(),
+  jobId: integer('job_id')
+    .notNull()
+    .references(() => jobs.id),
+  operationId: integer('operation_id').references(() => jobOperations.id),
+  dimension: varchar('dimension', { length: 255 }),
+  nominalSpec: varchar('nominal_spec', { length: 255 }),
+  actualValue: varchar('actual_value', { length: 255 }),
+  result: varchar('result', { length: 20 }),
+  inspector: varchar('inspector', { length: 255 }),
+  inspectedAt: timestamp('inspected_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
 export const teamsRelations = relations(teams, ({ many }) => ({
   teamMembers: many(teamMembers),
   activityLogs: many(activityLogs),
@@ -148,14 +163,30 @@ export const jobsRelations = relations(jobs, ({ one, many }) => ({
     references: [teams.id],
   }),
   operations: many(jobOperations),
+  inspectionRecords: many(inspectionRecords),
 }));
 
-export const jobOperationsRelations = relations(jobOperations, ({ one }) => ({
+export const jobOperationsRelations = relations(jobOperations, ({ one, many }) => ({
   job: one(jobs, {
     fields: [jobOperations.jobId],
     references: [jobs.id],
   }),
+  inspectionRecords: many(inspectionRecords),
 }));
+
+export const inspectionRecordsRelations = relations(
+  inspectionRecords,
+  ({ one }) => ({
+    job: one(jobs, {
+      fields: [inspectionRecords.jobId],
+      references: [jobs.id],
+    }),
+    operation: one(jobOperations, {
+      fields: [inspectionRecords.operationId],
+      references: [jobOperations.id],
+    }),
+  })
+);
 
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
@@ -171,6 +202,8 @@ export type Job = typeof jobs.$inferSelect;
 export type NewJob = typeof jobs.$inferInsert;
 export type JobOperation = typeof jobOperations.$inferSelect;
 export type NewJobOperation = typeof jobOperations.$inferInsert;
+export type InspectionRecord = typeof inspectionRecords.$inferSelect;
+export type NewInspectionRecord = typeof inspectionRecords.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -68,10 +68,27 @@ export const invitations = pgTable('invitations', {
   status: varchar('status', { length: 20 }).notNull().default('pending'),
 });
 
+export const jobs = pgTable('jobs', {
+  id: serial('id').primaryKey(),
+  teamId: integer('team_id')
+    .notNull()
+    .references(() => teams.id),
+  jobNumber: varchar('job_number', { length: 255 }).notNull(),
+  customerName: varchar('customer_name', { length: 255 }),
+  partNumber: varchar('part_number', { length: 255 }),
+  partRevision: varchar('part_revision', { length: 255 }),
+  quantity: integer('quantity'),
+  dueDate: timestamp('due_date'),
+  status: varchar('status', { length: 50 }).notNull().default('open'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
 export const teamsRelations = relations(teams, ({ many }) => ({
   teamMembers: many(teamMembers),
   activityLogs: many(activityLogs),
   invitations: many(invitations),
+  jobs: many(jobs),
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -112,6 +129,13 @@ export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
   }),
 }));
 
+export const jobsRelations = relations(jobs, ({ one }) => ({
+  team: one(teams, {
+    fields: [jobs.teamId],
+    references: [teams.id],
+  }),
+}));
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Team = typeof teams.$inferSelect;
@@ -122,6 +146,8 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type Job = typeof jobs.$inferSelect;
+export type NewJob = typeof jobs.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -84,6 +84,19 @@ export const jobs = pgTable('jobs', {
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });
 
+export const jobOperations = pgTable('job_operations', {
+  id: serial('id').primaryKey(),
+  jobId: integer('job_id')
+    .notNull()
+    .references(() => jobs.id),
+  sequence: integer('sequence').notNull(),
+  description: varchar('description', { length: 255 }),
+  machine: varchar('machine', { length: 255 }),
+  completedBy: varchar('completed_by', { length: 255 }),
+  completedAt: timestamp('completed_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
 export const teamsRelations = relations(teams, ({ many }) => ({
   teamMembers: many(teamMembers),
   activityLogs: many(activityLogs),
@@ -129,10 +142,18 @@ export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
   }),
 }));
 
-export const jobsRelations = relations(jobs, ({ one }) => ({
+export const jobsRelations = relations(jobs, ({ one, many }) => ({
   team: one(teams, {
     fields: [jobs.teamId],
     references: [teams.id],
+  }),
+  operations: many(jobOperations),
+}));
+
+export const jobOperationsRelations = relations(jobOperations, ({ one }) => ({
+  job: one(jobs, {
+    fields: [jobOperations.jobId],
+    references: [jobs.id],
   }),
 }));
 
@@ -148,6 +169,8 @@ export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
 export type Job = typeof jobs.$inferSelect;
 export type NewJob = typeof jobs.$inferInsert;
+export type JobOperation = typeof jobOperations.$inferSelect;
+export type NewJobOperation = typeof jobOperations.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;

--- a/lib/payments/seed-stripe.ts
+++ b/lib/payments/seed-stripe.ts
@@ -1,0 +1,77 @@
+import dotenv from 'dotenv';
+import Stripe from 'stripe';
+
+dotenv.config();
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2025-04-30.basil'
+});
+
+const PRODUCTS = [
+  {
+    name: 'OpsTrace Shop',
+    unitAmount: 29900,
+    metadata: { tier: 'shop', jobLimit: '100', userLimit: '3' }
+  },
+  {
+    name: 'OpsTrace Production',
+    unitAmount: 49900,
+    metadata: {
+      tier: 'production',
+      jobLimit: 'unlimited',
+      userLimit: '10'
+    }
+  },
+  {
+    name: 'OpsTrace Enterprise',
+    unitAmount: 79900,
+    metadata: {
+      tier: 'enterprise',
+      jobLimit: 'unlimited',
+      userLimit: 'unlimited'
+    }
+  }
+] as const;
+
+async function findProductByName(name: string): Promise<Stripe.Product | null> {
+  const result = await stripe.products.search({
+    query: `name:'${name}' AND active:'true'`
+  });
+
+  return result.data[0] ?? null;
+}
+
+async function seedStripe() {
+  for (const productDef of PRODUCTS) {
+    let product = await findProductByName(productDef.name);
+
+    if (!product) {
+      product = await stripe.products.create({
+        name: productDef.name,
+        metadata: productDef.metadata
+      });
+    }
+
+    const price = await stripe.prices.create({
+      product: product.id,
+      unit_amount: productDef.unitAmount,
+      currency: 'usd',
+      recurring: {
+        interval: 'month'
+      }
+    });
+
+    console.log(`${productDef.name}:`);
+    console.log(`  Product ID: ${product.id}`);
+    console.log(`  Price ID: ${price.id}`);
+  }
+}
+
+seedStripe()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('Stripe seed failed:', error);
+    process.exit(1);
+  });

--- a/lib/pdf/job-traveler.ts
+++ b/lib/pdf/job-traveler.ts
@@ -214,6 +214,7 @@ export async function generateJobTravelerPdf(
     const doc = new PDFDocument({
       size: 'LETTER',
       margin: PAGE_MARGIN,
+      bufferPages: true,
       info: {
         Title: `${job.jobNumber} Job Traveler`,
         Author: 'OpsTrace',

--- a/lib/pdf/job-traveler.ts
+++ b/lib/pdf/job-traveler.ts
@@ -1,0 +1,312 @@
+import 'server-only';
+
+import PDFDocument from 'pdfkit';
+import type { InspectionRecord, Job, JobOperation } from '@/lib/db/schema';
+
+const PAGE_MARGIN = 50;
+const HEADER_BG = '#e5e7eb';
+const BORDER_COLOR = '#d1d5db';
+const MUTED_COLOR = '#6b7280';
+
+function formatDate(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatDateTime(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function dash(value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') return '—';
+  return String(value);
+}
+
+type TableColumn = {
+  header: string;
+  width: number;
+  align?: 'left' | 'center' | 'right';
+};
+
+type TableRow = string[];
+
+function drawTable(
+  doc: PDFKit.PDFDocument,
+  startY: number,
+  columns: TableColumn[],
+  rows: TableRow[],
+  options?: { emptyMessage?: string }
+): number {
+  const tableWidth = doc.page.width - PAGE_MARGIN * 2;
+  const rowPadding = 6;
+  const headerHeight = 24;
+  const minRowHeight = 22;
+  let y = startY;
+
+  const drawHeader = () => {
+    doc.save();
+    doc.rect(PAGE_MARGIN, y, tableWidth, headerHeight).fill(HEADER_BG);
+    doc.strokeColor(BORDER_COLOR).lineWidth(0.5);
+    doc.rect(PAGE_MARGIN, y, tableWidth, headerHeight).stroke();
+
+    let x = PAGE_MARGIN;
+    doc.fillColor('#111827').font('Helvetica-Bold').fontSize(9);
+
+    for (const column of columns) {
+      doc.text(column.header, x + rowPadding, y + 7, {
+        width: column.width - rowPadding * 2,
+        align: column.align ?? 'left',
+        lineBreak: false,
+      });
+      x += column.width;
+    }
+
+    doc.restore();
+    y += headerHeight;
+  };
+
+  const ensureSpace = (height: number) => {
+    const bottom = doc.page.height - PAGE_MARGIN;
+    if (y + height > bottom) {
+      doc.addPage();
+      y = PAGE_MARGIN;
+      drawHeader();
+    }
+  };
+
+  drawHeader();
+
+  if (rows.length === 0) {
+    ensureSpace(minRowHeight);
+    doc.save();
+    doc.strokeColor(BORDER_COLOR).lineWidth(0.5);
+    doc.rect(PAGE_MARGIN, y, tableWidth, minRowHeight).stroke();
+    doc
+      .fillColor(MUTED_COLOR)
+      .font('Helvetica-Oblique')
+      .fontSize(9)
+      .text(options?.emptyMessage ?? 'No records.', PAGE_MARGIN + rowPadding, y + 7, {
+        width: tableWidth - rowPadding * 2,
+      });
+    doc.restore();
+    return y + minRowHeight + 16;
+  }
+
+  for (const row of rows) {
+    let rowHeight = minRowHeight;
+
+    for (let i = 0; i < columns.length; i++) {
+      const cellHeight = doc.heightOfString(row[i] ?? '—', {
+        width: columns[i].width - rowPadding * 2,
+        align: columns[i].align ?? 'left',
+      });
+      rowHeight = Math.max(rowHeight, cellHeight + rowPadding * 2);
+    }
+
+    ensureSpace(rowHeight);
+
+    doc.save();
+    doc.strokeColor(BORDER_COLOR).lineWidth(0.5);
+    doc.rect(PAGE_MARGIN, y, tableWidth, rowHeight).stroke();
+
+    let x = PAGE_MARGIN;
+    doc.fillColor('#111827').font('Helvetica').fontSize(9);
+
+    for (let i = 0; i < columns.length; i++) {
+      doc.text(row[i] ?? '—', x + rowPadding, y + rowPadding, {
+        width: columns[i].width - rowPadding * 2,
+        align: columns[i].align ?? 'left',
+      });
+      x += columns[i].width;
+    }
+
+    doc.restore();
+    y += rowHeight;
+  }
+
+  return y + 16;
+}
+
+function drawSectionTitle(doc: PDFKit.PDFDocument, title: string, y: number) {
+  const bottom = doc.page.height - PAGE_MARGIN;
+  if (y + 30 > bottom) {
+    doc.addPage();
+    y = PAGE_MARGIN;
+  }
+
+  doc.fillColor('#111827').font('Helvetica-Bold').fontSize(12).text(title, PAGE_MARGIN, y);
+  return y + 22;
+}
+
+function drawJobHeader(doc: PDFKit.PDFDocument, job: Job, y: number) {
+  const tableWidth = doc.page.width - PAGE_MARGIN * 2;
+  const colWidth = tableWidth / 2;
+  const rowHeight = 28;
+
+  const fields: [string, string][] = [
+    ['Job Number', dash(job.jobNumber)],
+    ['Customer', dash(job.customerName)],
+    ['Part Number', dash(job.partNumber)],
+    ['Revision', dash(job.partRevision)],
+    ['Quantity', dash(job.quantity)],
+    ['Due Date', formatDate(job.dueDate)],
+  ];
+
+  doc.save();
+  doc.strokeColor(BORDER_COLOR).lineWidth(0.5);
+
+  for (let i = 0; i < fields.length; i += 2) {
+    const rowY = y + (i / 2) * rowHeight;
+
+    doc.rect(PAGE_MARGIN, rowY, colWidth, rowHeight).stroke();
+    doc.rect(PAGE_MARGIN + colWidth, rowY, colWidth, rowHeight).stroke();
+
+    doc
+      .fillColor(MUTED_COLOR)
+      .font('Helvetica')
+      .fontSize(8)
+      .text(fields[i][0], PAGE_MARGIN + 8, rowY + 6, { width: colWidth - 16 });
+    doc
+      .fillColor('#111827')
+      .font('Helvetica-Bold')
+      .fontSize(10)
+      .text(fields[i][1], PAGE_MARGIN + 8, rowY + 16, { width: colWidth - 16 });
+
+    if (fields[i + 1]) {
+      doc
+        .fillColor(MUTED_COLOR)
+        .font('Helvetica')
+        .fontSize(8)
+        .text(fields[i + 1][0], PAGE_MARGIN + colWidth + 8, rowY + 6, {
+          width: colWidth - 16,
+        });
+      doc
+        .fillColor('#111827')
+        .font('Helvetica-Bold')
+        .fontSize(10)
+        .text(fields[i + 1][1], PAGE_MARGIN + colWidth + 8, rowY + 16, {
+          width: colWidth - 16,
+        });
+    }
+  }
+
+  doc.restore();
+  return y + (fields.length / 2) * rowHeight + 20;
+}
+
+export async function generateJobTravelerPdf(
+  job: Job,
+  operations: JobOperation[],
+  inspectionRecords: InspectionRecord[]
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({
+      size: 'LETTER',
+      margin: PAGE_MARGIN,
+      info: {
+        Title: `${job.jobNumber} Job Traveler`,
+        Author: 'OpsTrace',
+      },
+    });
+
+    const chunks: Buffer[] = [];
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    const generatedAt = new Date().toLocaleString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    doc
+      .fillColor('#111827')
+      .font('Helvetica-Bold')
+      .fontSize(20)
+      .text('Job Traveler', PAGE_MARGIN, PAGE_MARGIN, { align: 'left' });
+
+    doc
+      .fillColor(MUTED_COLOR)
+      .font('Helvetica')
+      .fontSize(9)
+      .text(`Generated ${generatedAt}`, PAGE_MARGIN, PAGE_MARGIN + 26, { align: 'left' });
+
+    let y = drawJobHeader(doc, job, PAGE_MARGIN + 52);
+
+    y = drawSectionTitle(doc, 'Operations', y);
+
+    const tableWidth = doc.page.width - PAGE_MARGIN * 2;
+    const operationColumns: TableColumn[] = [
+      { header: 'Seq', width: tableWidth * 0.07, align: 'center' },
+      { header: 'Description', width: tableWidth * 0.33 },
+      { header: 'Machine', width: tableWidth * 0.18 },
+      { header: 'Completed By', width: tableWidth * 0.2 },
+      { header: 'Completed At', width: tableWidth * 0.22 },
+    ];
+
+    const operationRows: TableRow[] = operations.map((operation) => [
+      dash(operation.sequence),
+      dash(operation.description),
+      dash(operation.machine),
+      dash(operation.completedBy),
+      formatDateTime(operation.completedAt),
+    ]);
+
+    y = drawTable(doc, y, operationColumns, operationRows, {
+      emptyMessage: 'No operations recorded.',
+    });
+
+    y = drawSectionTitle(doc, 'Inspection Records', y);
+
+    const inspectionColumns: TableColumn[] = [
+      { header: 'Dimension', width: tableWidth * 0.2 },
+      { header: 'Spec', width: tableWidth * 0.18 },
+      { header: 'Actual', width: tableWidth * 0.18 },
+      { header: 'Result', width: tableWidth * 0.14 },
+      { header: 'Inspector', width: tableWidth * 0.3 },
+    ];
+
+    const inspectionRows: TableRow[] = inspectionRecords.map((record) => [
+      dash(record.dimension),
+      dash(record.nominalSpec),
+      dash(record.actualValue),
+      dash(record.result),
+      dash(record.inspector),
+    ]);
+
+    drawTable(doc, y, inspectionColumns, inspectionRows, {
+      emptyMessage: 'No inspection records.',
+    });
+
+    const pageCount = doc.bufferedPageRange().count;
+    for (let i = 0; i < pageCount; i++) {
+      doc.switchToPage(i);
+      doc
+        .fillColor(MUTED_COLOR)
+        .font('Helvetica')
+        .fontSize(8)
+        .text(
+          `Page ${i + 1} of ${pageCount}`,
+          PAGE_MARGIN,
+          doc.page.height - PAGE_MARGIN + 20,
+          { align: 'center', width: doc.page.width - PAGE_MARGIN * 2 }
+        );
+    }
+
+    doc.end();
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  serverExternalPackages: ['pdfkit'],
   experimental: {
     ppr: true,
     clientSegmentCache: true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "esbuild",
+      "sharp"
+    ]
+  },
   "dependencies": {
     "@tailwindcss/postcss": "4.1.7",
     "@types/node": "^22.15.18",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jose": "^6.0.11",
     "lucide-react": "^0.511.0",
     "next": "15.6.0-canary.59",
+    "pdfkit": "^0.19.1",
     "postcss": "^8.5.3",
     "postgres": "^3.4.5",
     "radix-ui": "^1.4.2",
@@ -38,5 +39,8 @@
     "tw-animate-css": "^1.3.0",
     "typescript": "^5.8.3",
     "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/pdfkit": "^0.17.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "db:seed": "npx tsx lib/db/seed.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "stripe:seed": "tsx lib/payments/seed-stripe.ts"
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       next:
         specifier: 15.6.0-canary.59
         version: 15.6.0-canary.59(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      pdfkit:
+        specifier: ^0.19.1
+        version: 0.19.1
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -89,6 +92,10 @@ importers:
       zod:
         specifier: ^3.24.4
         version: 3.24.4
+    devDependencies:
+      '@types/pdfkit':
+        specifier: ^0.17.6
+        version: 0.17.6
 
 packages:
 
@@ -441,89 +448,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -590,24 +613,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.6.0-canary.58':
     resolution: {integrity: sha512-KMYPUdBTAITdgxRNjMKdG85bHsn3wu0KWPV2nftoov2/dVs5eFJ47w+m4upPdTgBXRAHY50OvS/nzf5mN/TXeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.6.0-canary.58':
     resolution: {integrity: sha512-myknT/if7wuwss0B/1Le7ymlN0Zr/DsfGji8b+XcqeFhoy1GxQerfTlrsblZTB6EIPIex1QPRUbpIcy+N9Qfpw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.6.0-canary.58':
     resolution: {integrity: sha512-3A1YLtmuot0pnZqDHV2iAfUrvQS0zp7xXUlqNb8flAJAu1Civ+2qt94l0kTfUjWHtFFUENyt2yEcXEqxuxEJfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.6.0-canary.58':
     resolution: {integrity: sha512-3hkMBi/Zbatqi9vwnh1zuOWQerS4CtUptn9cj4NRtVAJurzhfQBwz8RJIq/5f85XDkq0LxDrhyABZ+6RU7Un7Q==}
@@ -620,6 +647,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@petamoriken/float16@3.9.2':
     resolution: {integrity: sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==}
@@ -1355,24 +1390,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.7':
     resolution: {integrity: sha512-PjGuNNmJeKHnP58M7XyjJyla8LPo+RmwHQpBI+W/OxqrwojyuCQ+GUtygu7jUqTEexejZHr/z3nBc/gTiXBj4A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.7':
     resolution: {integrity: sha512-HMs+Va+ZR3gC3mLZE00gXxtBo3JoSQxtu9lobbZd+DmfkIxR54NO7Z+UQNPsa0P/ITn1TevtFxXTpsRU7qEvWg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.7':
     resolution: {integrity: sha512-MHZ6jyNlutdHH8rd+YTdr3QbXrHXqwIhHw9e7yXEBcQdluGwhpQY2Eku8UZK6ReLaWtQ4gijIv5QoM5eE+qlsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.7':
     resolution: {integrity: sha512-ANaSKt74ZRzE2TvJmUcbFQ8zS201cIPxUDm5qez5rLEwWkie2SkGtA4P+GPTj+u8N6JbPrC8MtY8RmJA35Oo+A==}
@@ -1408,6 +1447,9 @@ packages:
   '@types/node@22.15.18':
     resolution: {integrity: sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==}
 
+  '@types/pdfkit@0.17.6':
+    resolution: {integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==}
+
   '@types/react-dom@19.1.5':
     resolution: {integrity: sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==}
     peerDependencies:
@@ -1427,9 +1469,22 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   bcryptjs@3.0.2:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
     hasBin: true
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.24.5:
     resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
@@ -1459,6 +1514,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1490,6 +1549,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
 
   dotenv@16.5.0:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
@@ -1634,6 +1696,12 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -1686,6 +1754,9 @@ packages:
   jose@6.0.11:
     resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
 
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
     engines: {node: '>= 12.0.0'}
@@ -1715,24 +1786,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -1749,6 +1824,9 @@ packages:
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   lucide-react@0.511.0:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
@@ -1815,8 +1893,20 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pdfkit@0.19.1:
+    resolution: {integrity: sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  png-js@1.1.0:
+    resolution: {integrity: sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -1891,6 +1981,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -1978,6 +2071,10 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1992,6 +2089,12 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -2363,6 +2466,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.6.0-canary.58':
     optional: true
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@petamoriken/float16@3.9.2':
     optional: true
@@ -3194,6 +3301,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pdfkit@0.17.6':
+    dependencies:
+      '@types/node': 22.15.18
+
   '@types/react-dom@19.1.5(@types/react@19.1.4)':
     dependencies:
       '@types/react': 19.1.4
@@ -3216,7 +3327,19 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
   bcryptjs@3.0.2: {}
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.24.5:
     dependencies:
@@ -3247,6 +3370,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   csstype@3.1.3: {}
@@ -3263,6 +3388,8 @@ snapshots:
     optional: true
 
   detect-node-es@1.1.0: {}
+
+  dfa@1.2.0: {}
 
   dotenv@16.5.0: {}
 
@@ -3366,6 +3493,20 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
+
   fraction.js@4.3.7: {}
 
   function-bind@1.1.2: {}
@@ -3423,6 +3564,8 @@ snapshots:
 
   jose@6.0.11: {}
 
+  js-md5@0.8.3: {}
+
   lightningcss-darwin-arm64@1.30.1:
     optional: true
 
@@ -3467,6 +3610,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lucide-react@0.511.0(react@19.1.0):
     dependencies:
@@ -3519,7 +3667,24 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  pako@0.2.9: {}
+
+  pako@1.0.11: {}
+
+  pdfkit@0.19.1:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      fontkit: 2.0.4
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 1.1.0
+
   picocolors@1.1.1: {}
+
+  png-js@1.1.0:
+    dependencies:
+      browserify-zlib: 0.2.0
 
   postcss-value-parser@4.2.0: {}
 
@@ -3640,6 +3805,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  restructure@3.0.2: {}
+
   scheduler@0.26.0: {}
 
   semver@7.7.3:
@@ -3751,6 +3918,8 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
+  tiny-inflate@1.0.3: {}
+
   tslib@2.8.1: {}
 
   tw-animate-css@1.3.0: {}
@@ -3758,6 +3927,16 @@ snapshots:
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
+
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   update-browserslist-db@1.1.3(browserslist@4.24.5):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true
+  sharp: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "baseUrl": ".",
     "plugins": [
@@ -33,7 +33,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary

This PR transforms OpsTrace from a basic job traveler CRUD app into an audit-ready compliance tool for precision machine shops doing defense, aerospace, and medical contract work. Every CRITICAL compliance gap identified in the codebase audit has been resolved.

The core promise — "when an auditor walks in, the shop hands them a complete, tamper-evident digital record and the auditor leaves satisfied" — is now backed by real implementation, not just marketing copy.

## What Changed

### Immutable Inspection Sign-offs (9B)
- **Schema:** Added `userId` (FK to authenticated user) and `lockedAt` (server-side timestamp) to `inspection_records`
- **Server action:** Inspector name and timestamp are now set server-side from the authenticated session — no longer user-supplied form inputs
- **UI:** Removed manual Inspector and Inspected At fields. Form now shows "Signed off by {user} · Timestamp set automatically" and only collects measurement data (dimension, spec, actual, pass/fail)
- **Immutability:** No update or delete actions exist for inspection records. Compliance comment documents the append-only design
- **Migration:** `0004_absent_cardiac.sql`

### Compliance Audit Trail (9C)
- **Schema:** Added `targetType`, `targetId`, and `metadata` (jsonb) to `activity_logs`
- **15 ActivityTypes** now tracked: auth events + CREATE_JOB, CREATE_OPERATION, COMPLETE_OPERATION, CREATE_INSPECTION_RECORD, EXPORT_PDF
- **Shared helper:** `lib/activity/log.ts` — used by all server actions and API routes
- **New page:** `/dashboard/audit-log` — team-wide compliance log, paginated (25/page), filterable by action type, read-only
- **Sidebar:** "Audit Log" link added between Jobs and Team
- **Query:** `getTeamAuditLog()` — team-scoped, paginated, joined with users table
- **Migration:** `0005_adorable_fallen_one.sql`

### Tamper-Evident PDF Compliance Packet (9D)
- **Cover page:** Job metadata, generation attribution, compliance disclaimer
- **Operations table:** Shows PENDING for incomplete operations
- **Inspection table:** Expanded from 5 to 7 columns — added Date/Time and Operation linkage. FAIL results rendered in bold
- **Record History section:** Full job-scoped audit trail embedded in the PDF
- **Document Integrity:** SHA-256 hash computed from all document data and displayed on final page
- **Footer:** Every page shows "OpsTrace Compliance Record — Job {number} — Page N of M — Generated {timestamp} by {user}"
- **API route:** Fetches audit log entries for the job and passes to PDF generator. EXPORT_PDF event logged after generation

### Route Conflict Fixes (9E)
- **Deleted:** `app/(dashboard)/page.tsx` (duplicate `/` route, leftover from saas-starter)
- **Deleted:** `app/(dashboard)/pricing/page.tsx` (duplicate `/pricing` route)
- **Deleted:** `app/(dashboard)/terminal.tsx` and `submit-button.tsx` (orphaned components)
- **Kept:** `app/(marketing)/page.tsx` (OpsTrace landing page) and `app/(marketing)/pricing/page.tsx` (three-tier pricing)
- **Build:** `pnpm build` passes cleanly with no route conflicts

## Files Changed

### Added
- `lib/activity/log.ts` — shared audit logging helper
- `app/(dashboard)/dashboard/audit-log/page.tsx` — compliance audit log viewer
- `app/(dashboard)/dashboard/audit-log/audit-log-utils.tsx` — formatting helpers
- `lib/db/migrations/0004_absent_cardiac.sql` — inspection_records: userId, lockedAt
- `lib/db/migrations/0005_adorable_fallen_one.sql` — activity_logs: targetType, targetId

### Modified
- `lib/db/schema.ts` — inspectionRecords + activityLogs columns, ActivityType enum
- `lib/db/queries.ts` — getTeamAuditLog(), getJobAuditLogForTeam()
- `lib/pdf/job-traveler.ts` — complete rewrite: cover page, 7-column inspections, audit trail section, SHA-256 hash, updated footer
- `app/api/jobs/[id]/traveler-pdf/route.ts` — fetches audit log, passes to PDF generator, logs EXPORT_PDF
- `app/(dashboard)/dashboard/jobs/actions.ts` — immutable inspection sign-offs, audit logging on all core actions
- `app/(dashboard)/dashboard/jobs/[id]/job-inspection-records.tsx` — removed manual inputs, added lock icon
- `app/(dashboard)/dashboard/layout.tsx` — sidebar: added Audit Log link
- `app/(dashboard)/dashboard/activity/page.tsx` — added CREATE_INSPECTION_RECORD icon/label
- `app/(login)/actions.ts` — uses shared logActivity from lib/activity/log.ts

### Deleted
- `app/(dashboard)/page.tsx` — duplicate route
- `app/(dashboard)/pricing/page.tsx` — duplicate route
- `app/(dashboard)/pricing/submit-button.tsx` — orphaned
- `app/(dashboard)/terminal.tsx` — orphaned

## Compliance Gaps Resolved

| Gap | Status |
|-----|--------|
| Inspection records not locked after creation | ✅ Fixed — lockedAt timestamp, no edit/delete |
| Inspector identity not bound to authenticated user | ✅ Fixed — userId FK + server-set name |
| Inspection timestamp user-supplied | ✅ Fixed — server-generated |
| No audit logging for core actions | ✅ Fixed — 5 new action types logged |
| Audit log lacks target references | ✅ Fixed — targetType + targetId |
| No team-wide audit log viewer | ✅ Fixed — /dashboard/audit-log |
| PDF missing inspection timestamps | ✅ Fixed — 7-column table |
| PDF missing audit trail | ✅ Fixed — Record History section |
| No tamper-evident hash | ✅ Fixed — SHA-256 on every PDF |
| Marketing claims not matching reality | ✅ Fixed — implementation now matches |
| Duplicate routes blocking build | ✅ Fixed — deleted duplicates |

## Testing

```bash
pnpm tsc --noEmit   # passes
pnpm build          # passes (exit code 0)
```

### Manual Test Checklist
- [ ] Sign in with test@test.com / admin123
- [ ] Create a new job
- [ ] Add 2-3 operations
- [ ] Mark one operation complete
- [ ] Add an inspection record — verify no Inspector or Inspected At fields in form
- [ ] Verify inspection shows lock icon, server timestamp, and authenticated user name
- [ ] Download PDF — verify cover page, 7-column inspections, audit trail, SHA-256 hash
- [ ] Visit /dashboard/audit-log — verify all actions are logged with timestamps
- [ ] Verify no edit or delete controls exist on inspections or audit log entries

## Build Warnings (non-blocking)
- `baseline-browser-mapping` data over two months old
- Next.js anonymous telemetry notice
- Middleware convention deprecated (Next.js 15 canary)
- Experimental flags: ppr, rdcForNavigations